### PR TITLE
Container system

### DIFF
--- a/public/ProvenanceForm.js
+++ b/public/ProvenanceForm.js
@@ -24,10 +24,18 @@ export default {
         <label for="provenance-tags" class="form-label mt-3" >Tags (will be converted to lower case and duplicates removed)</label>
         <${TagInput} modelValue=${this.tags} name="tags" id="provenance-tags" class="form-control" onUpdateTags=${(value) => { this.tags = value }}/>
         <div class="my-1">${this.nonEmptyTags.map(t => html`<span class="badge bg-info text-dark mx-1">${t}</span>`)}</div>
+
+        <label class="form-label">Children Keys (optional) </label>
+        <input type="text" class="form-control" name="children" id="children-keys" />
+
+        <label class="form-label">Parent Key (optional) </label>
+        <input type="text" class="form-control" name="parent" id="parent-key" />
+        
         <label class="form-label" for="file">Add Image</label>
         <input type="file" class="form-control" accept="image/*" name="picture" capture="environment" />
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>
+
 </form>
 `
     }

--- a/public/ProvenanceForm.js
+++ b/public/ProvenanceForm.js
@@ -20,7 +20,7 @@ export default {
 <form method="POST" class="col-md-8 card p-3 text-bg-secondary" enctype="multipart/form-data">
     <legend>Create New Provenance Record</legend>
     <div class="mb-3">
-        <input type="text" class="form-control" name="description" id="provenance-description" required placeholder="Provenance Description" />
+        <input type="text" class="form-control" name="description" id="provenance-description" placeholder="Provenance Description (optional)" />
         <label for="provenance-tags" class="form-label mt-3" >Tags (will be converted to lower case and duplicates removed)</label>
         <${TagInput} modelValue=${this.tags} name="tags" id="provenance-tags" class="form-control" onUpdateTags=${(value) => { this.tags = value }}/>
         <div class="my-1">${this.nonEmptyTags.map(t => html`<span class="badge bg-info text-dark mx-1">${t}</span>`)}</div>

--- a/server.ts
+++ b/server.ts
@@ -246,9 +246,11 @@ export async function createFastifyServer(deviceRepo: DeviceRepository, recordRe
         async function recallChildren(deviceKey: string) {
             const childList = await recordRepo.getChildren(deviceKey);
             // need to obtain each provenance record, then in each key of provenance record
+            const onlyChildKeys = [];
             for (var child of childList) {
                 if (child.children_key) {
                     for (var child_key of child.children_key) {
+                        onlyChildKeys.push(child_key);
                         await recordRepo.createRecord(child_key, description, {
                             tags: [...tagSet],
                             attachments: picture ? [picture] : undefined,
@@ -257,6 +259,8 @@ export async function createFastifyServer(deviceRepo: DeviceRepository, recordRe
                     }
                 }
             } 
+            const json = JSON.stringify(onlyChildKeys);
+            console.log("json file of children keys ", JSON.parse(json.toString()));
             return;
         }
 

--- a/server.ts
+++ b/server.ts
@@ -183,9 +183,11 @@ export async function createFastifyServer(deviceRepo: DeviceRepository, recordRe
                 //should try to add some boolean that says this device already has a parent?
     
                 const parentDeviceChildrenWarnings = await addChildren(parentKey, new Set([deviceKey]));
+                console.log("this is the parent device: ", parentDeviceChildrenWarnings);
                 await recordRepo.createRecord(parentKey, description, {
                     tags: [...tagSet],
                     attachments: picture ? [picture] : undefined,
+                    children_key: [...parentDeviceChildrenWarnings.childKeys],
                     children_name: [...parentDeviceChildrenWarnings.childrenNames],
                     warnings: [...parentDeviceChildrenWarnings.warnings],
                 });    
@@ -221,6 +223,7 @@ export async function createFastifyServer(deviceRepo: DeviceRepository, recordRe
                 }                      
             }
             return {
+                childKeys : childKeySet,
                 childrenNames: childNameSet, 
                 warnings: warningSet };
         }
@@ -229,7 +232,7 @@ export async function createFastifyServer(deviceRepo: DeviceRepository, recordRe
         await recordRepo.createRecord(deviceKey, description, {
             tags: [...tagSet],
             attachments: picture ? [picture] : undefined,
-            children_key: [...childKeySet],
+            children_key: [...deviceProvenance.childKeys],
             children_name: [...deviceProvenance.childrenNames],
             warnings: [...deviceProvenance.warnings],
         });

--- a/services/sequelizeRepo.ts
+++ b/services/sequelizeRepo.ts
@@ -176,7 +176,7 @@ function createProvenanceRepo(
         });
         return records.map(record => {
             const data = decrypt($key, record.salt, record.data);
-            const $record = JSON.parse(data.toString('utf8'), (k,v) => k === 'attachmentID' ? BigInt(v) : v) as ProvenanceRecordJson;
+            const $record = JSON.parse(data.toString('utf8')) as ProvenanceRecordJson;
             return <ProvenanceRecord>{
                 children_key: $record.children_key,
                 children_name: $record.children_name,

--- a/services/sequelizeRepo.ts
+++ b/services/sequelizeRepo.ts
@@ -160,7 +160,7 @@ function createProvenanceRepo(
                 attachments: $record.attachments,
                 children_key: $record.children_key,
                 children_name: $record.children_name,
-                warnings: $record.warnings ?? [],
+                warnings: $record.warnings,
                 createdAt: record.createdAt
             }
         });

--- a/services/types.ts
+++ b/services/types.ts
@@ -2,14 +2,18 @@ export interface Device {
     readonly name: string;
     readonly key: string;
     readonly deviceID: bigint;
+    readonly parent_of?: (string | Uint8Array)[];
 }
 
 export interface ProvenanceRecord {
     readonly deviceID: bigint;
     readonly name?: string;
-    readonly description: string;
+    readonly description?: string;
     readonly attachments: readonly Pick<ProvenanceAttachment, 'type' | 'attachmentID'>[];
     readonly tags: readonly string[];
+    readonly children_key?: readonly string[];
+    readonly children_name?: readonly string[]
+    readonly warnings?: readonly string[];
     readonly createdAt: Date;
 }
 
@@ -25,6 +29,9 @@ export interface CreateRecordOptions {
     readonly name?: string;
     readonly attachments?: readonly Pick<ProvenanceAttachment, 'type' | 'data'>[];
     readonly tags?: readonly string[];
+    readonly children_key?: readonly string[];
+    readonly children_name?: readonly string[];
+    readonly warnings?: readonly string[];
     readonly createdAt?: Date;
 }
 
@@ -34,10 +41,13 @@ export interface DeviceRepository {
     createDevice(name: string, key?: string | Uint8Array): Promise<Device>;
     getDevice(key: string | Uint8Array): Promise<Device | null>;
     getDevices(): Promise<readonly Device[]>;
+
+    //something like add children
 }
 
 export interface ProvenanceRepository {
     createRecord(key: string | Uint8Array, description: string, options?: CreateRecordOptions) : Promise<ProvenanceRecord>;
     getRecords(key: string | Uint8Array): Promise<readonly ProvenanceRecord[]>;
+    getChildren(key: string | Uint8Array): Promise<readonly ProvenanceRecord[]>;
     getAttachment(key: string | Uint8Array, attachmentID: bigint): Promise<ProvenanceAttachment | null>;
 }

--- a/views/provenance.liquid
+++ b/views/provenance.liquid
@@ -18,7 +18,28 @@
                     <a href="/provenance/{{ deviceKey }}/attachment/{{ attachment.attachmentID }}">{{ attachment.attachmentID }}</a>
                 {% endif %}
             {% endfor %}
+
+            <div style="font-size: small;">
+
+            {% assign int = 0 %}
+            {% for child in report.children_key %}
+                {% if child.name != "" %}
+                    Added child device:
+                    <a href="/provenance/{{child}}">{{ report.children_name[int] }} </a> <br>    
+                    {% assign int = int | plus: 1%}     
+                {% endif %}
+                
+            {% endfor %}
+            </div>
+
+            <div style="font-size: small;">
+            {% for warn in report.warnings %}
+                <b> {{ warn }}  </b><br>                    
+            {% endfor %}
+            </div>
+            
             <div style="font-size: small;">{{ report.createdAt }}</div>
+
         </div>
     {% endfor -%}
     </div>


### PR DESCRIPTION
fixes #52 

- Users can enter either a child key or a parent key.
- If a child key is entered, users are given direct access to the child's records (link to the records is automatically given). However, if a parent key is entered, users DO NOT have direct access (link to parent records is not automatically given).
- Users can use "recall" tag to recall all of the devices children, grandchildren, and so on. A record is then added to all children (and grandchildren and so on) with the tag "recall".