### PR TITLE
preventing circular relationships

### DIFF
--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -178,9 +178,17 @@ export default {
                 }
             }
 
-            if (this.childrenKey.length > 1) {
-                console.log("children keys have been entered");
-            } else {console.log("empty children");}
+            if (this.childrenKey.length > 1) { // if children keys have been entered
+                let string_children = this.childrenKey.toString()
+                let list_children = string_children.split(",");
+                for (let i of list_children) {
+                    // for each key, check its descendants and see if current device is a child of them
+                    let descendants = this.getChildrenKeys(i);
+                    if ((await descendants).includes(this.deviceKey)) {
+                        this.description = "Error: Child device could not be added."
+                    }
+                }
+            } 
 
         const index = this.tags.indexOf("recall", 0);
         

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -185,6 +185,7 @@ export default {
                 for (let i of entered_children) {
                     // for each key, check its descendants and see if current device is a child of them
                     // make sure that the entered child does not have a parent yet
+                    // TODO: make sure the child exists
                     const child_prov = await getProvenance(i);
                     const child_record = child_prov[0].record;
                     let index = entered_children.lastIndexOf(i);
@@ -269,7 +270,7 @@ export default {
             this.submitRecord()
             .then(response=> {
                 console.log("form is submitted!");
-                // window.location.reload(); //once they submit it just reloads the entire page.
+                window.location.reload(); //once they submit it just reloads the entire page.
             }); 
         },
     }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -259,7 +259,7 @@ export default {
             this.submitRecord()
             .then(response=> {
                 console.log("form is submitted!");
-                // window.location.reload(); //once they submit it just reloads the entire page.
+                window.location.reload(); //once they submit it just reloads the entire page.
             }); 
         },
     }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -218,11 +218,11 @@ export default {
             } 
 
         const recall = this.tags.indexOf("recall", 0);
-        const notify = this.tags.indexOf("notify_all", 0);
+        const inform = this.tags.indexOf("inform_all", 0);
         
 
         // "recall" is being added....
-        if (recall > -1 || notify > -1) {
+        if (recall > -1 || inform > -1) {
             let reason = ""
             let tags = this.tags
             if (recall > -1) { 
@@ -236,7 +236,7 @@ export default {
                 // console.log("begin to recall");
                 await this.recursivelyRecallChildren(descendantsList, reason, tags)
                 .then(response => {
-                    console.log("Finished recalling/notifying");
+                    console.log("Finished recalling/informing");
                 })
             }
             

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -183,8 +183,8 @@ export default {
                 let list_children = string_children.split(",");
                 for (let i of list_children) {
                     // for each key, check its descendants and see if current device is a child of them
-                    let descendants = this.getChildrenKeys(i);
-                    if ((await descendants).includes(this.deviceKey)) {
+                    let descendants = await this.getChildrenKeys(i);
+                    if (descendants.includes(this.deviceKey)) {
                         this.description = "Error: Child device could not be added."
                     }
                 }
@@ -236,7 +236,7 @@ export default {
             this.submitRecord()
             .then(response=> {
                 console.log("form is submitted!");
-                // window.location.reload(); //once they submit it just reloads the entire page.
+                window.location.reload(); //once they submit it just reloads the entire page.
             }); 
         },
     }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -148,29 +148,42 @@ export default {
             let local_deviceRecord = response[0].record;
             this.hasParent = local_deviceRecord.hasParent;
             this.isReportingKey = local_deviceRecord.isReportingKey;
+            let childrenList = await this.getChildrenKeys(this.deviceKey);
 
             //here we post provenance if a container (parent) key was entered
             if (this.containerKey != '') {
 
                 if (this.hasParent) {
                     console.log("This device already has a container.");
+                    this.description = "Error: Container could not be added.";
+
                 } else {
-
-                    postProvenance(this.containerKey, {
-                        blobType: 'deviceRecord',
-                        description: this.description,
-                        tags: this.tags,
-                        children_key: [this.deviceKey],
-                        hasParent: true,
-                    }, this.pictures || [])
-
-                    this.hasParent = true;
+                    // need to check if this parent is NOT a child of the device already
+                    if (childrenList.indexOf(this.containerKey, 0) > -1) { //check if container key is among children
+                        // container is INDEED a child of this device
+                        // therefore, this relationship shouldn't be created
+                        console.log("This container is a child of this device.");
+                        this.description = "Error: Container could not be added.";
+                    } else{
+                        postProvenance(this.containerKey, {
+                            blobType: 'deviceRecord',
+                            description: this.description,
+                            tags: this.tags,
+                            children_key: [this.deviceKey],
+                            hasParent: true,
+                        }, this.pictures || [])
+    
+                        this.hasParent = true;
+                    }
                 }
             }
 
+            if (this.childrenKey.length > 1) {
+                console.log("children keys have been entered");
+            } else {console.log("empty children");}
+
         const index = this.tags.indexOf("recall", 0);
         
-        let childrenList = await this.getChildrenKeys(this.deviceKey);
 
         // "recall" is being added....
         if (index > -1) {
@@ -215,7 +228,7 @@ export default {
             this.submitRecord()
             .then(response=> {
                 console.log("form is submitted!");
-                window.location.reload(); //once they submit it just reloads the entire page.
+                // window.location.reload(); //once they submit it just reloads the entire page.
             }); 
         },
     }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -159,11 +159,11 @@ export default {
                     this.description = this.description + "\nError: Container could not be added.";
 
                 } else {
-                    // need to check if this parent is NOT a child of the device already
-                    if (descendantsList.indexOf(this.containerKey, 0) > -1) { //check if container key is among children
-                        // container is INDEED a child of this device
+                    // need to check if this parent is NOT a descendant of the device already
+                    if (descendantsList.indexOf(this.containerKey, 0) > -1) { //check if container key is among descendants
+                        // container is INDEED a descendant of this device
                         // therefore, this relationship shouldn't be created
-                        console.log("This container is a child of this device.");
+                        console.log("This container is a descendant of this device.");
                         this.description = this.description + `\nError: Container could not be added.`;
                     } else{
                         postProvenance(this.containerKey, {
@@ -179,7 +179,7 @@ export default {
                 }
             }
 
-            if (this.childrenKey.length > 1) { // if children keys have been entered
+            if (this.childrenKey.length > 1) { // if user want to add children keys 
                 let string_children = this.childrenKey.toString();
                 let entered_children = string_children.split(",");
                 for (let i of entered_children) {

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -185,8 +185,11 @@ export default {
                     // for each key, check its descendants and see if current device is a child of them
                     let descendants = await this.getChildrenKeys(i);
                     if (descendants.includes(this.deviceKey)) {
-                        this.description = this.description + `\nError: Child device could not be added.`
+                        this.description = this.description + `\nError: Child device could not be added.`;
+                        let index = list_children.lastIndexOf(i);
+                        list_children.splice(index, 1);
                     }
+                this.childrenKey = list_children;
                 }
             } 
 
@@ -206,6 +209,7 @@ export default {
                 // reporting keys do not have the ability to recall
                 console.log("Action failed. This is a reporting key.");
             } else {
+                // console.log("begin to recall");
                 await this.recursivelyRecallChildren(childrenList, reason, tags)
                 .then(response => {
                     console.log("Finished recalling/notifying");

--- a/packages/frontend/pages/device/[deviceKey].vue
+++ b/packages/frontend/pages/device/[deviceKey].vue
@@ -29,15 +29,15 @@ const deviceKey = route.params.deviceKey;
     </div>
     </nav>
 
-  <div class="container-md my-4">
+  <div class="container-md my-4" v-if="!isLoading">
     <div class="row justify-content-between">
         <div class="col-sm-6 col-lg-9">
 
-            <div class="mt-4 mb-2 text-iris fs-1" v-if="!isLoading">{{deviceRecord.deviceName}}</div>
+            <div class="mt-4 mb-2 text-iris fs-1" >{{deviceRecord.deviceName}}</div>
             <!-- TODO: We might want to call this an Admin key if it has a reporting key -->
         
             <div>Device Key: {{ route.params.deviceKey }}</div>
-            <div class="my-2" v-if="!isLoading">{{deviceRecord.description}}</div>
+            <div class="my-2" >{{deviceRecord.description}}</div>
         
             <div> 
                 <button class="btn mt-1 bg-iris text-white me-4 px-4"><a :href="`/provenance/${route.params.deviceKey}`" style="color: white; text-decoration: none">View Provenance Records</a></button>
@@ -58,7 +58,7 @@ const deviceKey = route.params.deviceKey;
 
 
     <!--Put the Reporting Key here if there is one -->
-    <div v-if="!isLoading">
+    <div>
         <div v-if="hasReportingKey" class="mt-4 mb-2 text-iris fs-2">
         Reporting Key:
         </div>

--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -138,5 +138,6 @@ export default {
 }
 body {
     margin: 50px;
+    white-space: pre-line;
 }
 </style>


### PR DESCRIPTION
fixes issue #151 

This prevents a device from becoming simultaneously both a parent and a descendant of another device. 
![circular_relationship](https://github.com/gosqasorg/asset-provenance-tracking/assets/83525666/1d6adaa0-8cb9-46fa-8d52-bac39eff9c75)

When the user adds a device that creates such relationship, an error is displayed.
<img width="340" alt="adding_child_circular" src="https://github.com/gosqasorg/asset-provenance-tracking/assets/83525666/523b9f7c-0187-42bc-b778-7165715477fc">
<img width="339" alt="adding_container_circular" src="https://github.com/gosqasorg/asset-provenance-tracking/assets/83525666/c1232548-c317-407a-8d55-ae0d37a12377">

