### PR TITLE
Fixing color tag bug

### DIFF
--- a/packages/frontend/utils/colorTag.ts
+++ b/packages/frontend/utils/colorTag.ts
@@ -118,18 +118,6 @@ const colors = [
   "#eb1d1a",
 ];
 
-// interface AssociativeArray {
-//   [key: string]: string
-// }
-
-// var designedTags: AssociativeArray[] = []
-// designedTags['recall'] = "#ff0000"; // Red
-// designedTags['good'] = "#00ff00"; // Green
-// designedTags['bad'] = "#dc143c"; // Crimson
-// designedTags['received'] = "#0000cd"; // MediumBlue
-// designedTags['inspected'] = "#6495ed"; // CornflowerBlue
-// designedTags['sent'] = "#ffff00"; // Yellow
-
 let designedTags : { [key:string]: string } = {
   "recall": "#ff0000", // Red
   "good": "#00ff00", //Green

--- a/packages/frontend/utils/colorTag.ts
+++ b/packages/frontend/utils/colorTag.ts
@@ -118,17 +118,26 @@ const colors = [
   "#eb1d1a",
 ];
 
-interface AssociativeArray {
-  [key: string]: string
-}
+// interface AssociativeArray {
+//   [key: string]: string
+// }
 
-var designedTags: AssociativeArray[] = []
-designedTags['recall'] = "#ff0000"; // Red
-designedTags['good'] = "#00ff00"; // Green
-designedTags['bad'] = "#dc143c"; // Crimson
-designedTags['received'] = "#0000cd"; // MediumBlue
-designedTags['inspected'] = "#6495ed"; // CornflowerBlue
-designedTags['sent'] = "#ffff00"; // Yellow
+// var designedTags: AssociativeArray[] = []
+// designedTags['recall'] = "#ff0000"; // Red
+// designedTags['good'] = "#00ff00"; // Green
+// designedTags['bad'] = "#dc143c"; // Crimson
+// designedTags['received'] = "#0000cd"; // MediumBlue
+// designedTags['inspected'] = "#6495ed"; // CornflowerBlue
+// designedTags['sent'] = "#ffff00"; // Yellow
+
+let designedTags : { [key:string]: string } = {
+  "recall": "#ff0000", // Red
+  "good": "#00ff00", //Green
+  'bad': "#dc143c", // Crimson
+  'received':"#0000cd", // MediumBlue
+  'inspected': "#6495ed", // CornflowerBlue
+  'sent': "#ffff00" // Yellow
+}
 
 
 // Function to generate hash.


### PR DESCRIPTION
This fixes issue #186 

The issue seemed to be that the tag "at" was detected as a designed tag but since it is actually NOT a designed tag, it returns an undefined value. I changed the syntax of how we defined `designedTags` and it fixed the issue. Image below shows old code as commented.
<img width="374" alt="designedtagscode" src="https://github.com/user-attachments/assets/2650278a-fb5b-4a2e-af21-847da9b19fa6">


Image below shows tag "at" working. 
<img width="517" alt="tags" src="https://github.com/user-attachments/assets/69d1e812-52e9-4d38-a26a-14cb673a77f0">

