### PR TITLE
Changing csv format

### DIFF
--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -19,7 +19,11 @@ export default {
 
     methods: {
         async downloadCSV() {
-            const keyList = await getChildrenKeys(this.deviceKey);
+            let keyList = await getChildrenKeys(this.deviceKey);
+            // Convert key to a link
+            keyList = keyList.map(key => 'https://gosqas.org/provenance/' + key);
+            // Replace comas with new lines
+            keyList = String(keyList).replaceAll(",", "\n");
 
             const anchor = document.createElement('a');
             anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(keyList);


### PR DESCRIPTION
Fixes issue #210. Current csv file separates each key in a new line rather than a coma. In addition, each key has been converted to a link to its provenance. This is the current format: https://gosqas.org/provenance/{key}.