### PR TITLE
Adding buttons to pages

### DIFF
--- a/packages/frontend/assets/styles/main.scss
+++ b/packages/frontend/assets/styles/main.scss
@@ -115,6 +115,11 @@ h1 {
         font-weight: 600;
         line-height: 72px;
     }
+
+    h2 {
+        font-size: 40px;
+        line-height: 60px;
+    }
  
  
     h3 {

--- a/packages/frontend/components/TrackAsset.vue
+++ b/packages/frontend/components/TrackAsset.vue
@@ -1,0 +1,70 @@
+<!-- TrackAsset.vue
+Copyright (C) 2024 GOSQAS Team
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
+<!--
+    This is the component that shows users an input field to enter
+    a device key to be tracked.
+-->
+
+
+<template>
+    <form @submit.prevent="submit">
+        <input type="text" id="input" v-model="deviceKey" placeholder="Device key" style="width: inputWidth;" required/>
+        <button-component buttonText="Track asset" padding="12px 16px"
+            type="submit" style="font-size: 16px;"></button-component>
+    </form>
+</template>
+
+<script lang="ts">
+
+export default {
+    props: {
+        inputWidth: { type: String, default: "100%" }
+    },
+    data() {
+        return {
+            deviceKey: ''
+        }
+    },
+    mounted() {
+        let inputField = document.getElementById("input") as HTMLDivElement;
+        inputField.style.width = this.inputWidth;
+    },
+    methods: {
+        async submit() {
+            this.$router.push({ path: `/provenance/${this.deviceKey}` });
+        }
+    }
+}
+
+</script>
+
+<style scoped>
+
+input {
+    border: 1px solid #CBD5E1;
+    border-radius: 6px;
+    line-height: 48px;
+    margin-right: 15px;
+}
+
+input::placeholder{
+    padding-left: 5px;
+}
+
+form {
+    width: 100%;
+}
+
+</style>

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <span style="font-weight: 400;" class="text-decoration-underline text-iris"> gosqasystem@gmail.com</span> 
                     or visiting the links below.</p>
         <span>
-            <button-component buttonText="How It Works" color="#322253" margin="0px 20px 0px 0px"
+            <button-component buttonText="How It Works" color="#322253" margin="0px 20px 20px 0px"
                 backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'"></button-component>                
             <button-component buttonText="Data & Privacy" color="#322253" margin="0px 20px 0px 0px" onclick="window.location.href='data_privacy'"
                 backgroundColor="#ffffff00"></button-component>                

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -24,12 +24,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <p style="font-weight: 400;"> Learn more about Global Open Source Quality Assurance System (GOSQAS) by emailing us at 
         <span style="font-weight: 400;" class="text-decoration-underline text-iris"> gosqasystem@gmail.com</span> 
                     or visiting the links below.</p>
-        <button-component buttonText="How It Works" color="#322253"
-            backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'"></button-component>                
-        <button-component buttonText="Data & Privacy" color="#322253"
-            backgroundColor="#ffffff00"></button-component>                
-        <button-component buttonText="GDT GitHub" color="#322253"
-            backgroundColor="#ffffff00"></button-component>
+        <span>
+            <button-component buttonText="How It Works" color="#322253" margin="0px 20px 0px 0px"
+                backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'"></button-component>                
+            <button-component buttonText="Data & Privacy" color="#322253" margin="0px 20px 0px 0px" onclick="window.location.href='data_privacy'"
+                backgroundColor="#ffffff00"></button-component>                
+            <button-component buttonText="GDT GitHub" color="#322253" onclick="location.href='https://github.com/gosqasorg/asset-provenance-tracking'"
+                backgroundColor="#ffffff00"></button-component>
+        </span>
     </div>
 
 </template>

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -26,11 +26,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                     or visiting the links below.</p>
         <span>
             <button-component buttonText="How It Works" color="#322253" margin="0px 20px 20px 0px"
-                backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'"></button-component>                
+                backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'" style="font-size:18px"></button-component>                
             <button-component buttonText="Data & Privacy" color="#322253" margin="0px 20px 0px 0px" onclick="window.location.href='data_privacy'"
-                backgroundColor="#ffffff00"></button-component>                
+                backgroundColor="#ffffff00" style="font-size:18px"></button-component>                
             <button-component buttonText="GDT GitHub" color="#322253" onclick="location.href='https://github.com/gosqasorg/asset-provenance-tracking'"
-                backgroundColor="#ffffff00"></button-component>
+                backgroundColor="#ffffff00" style="font-size:18px"></button-component>
         </span>
     </div>
 

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -20,12 +20,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 <template>
 
     <div class="row" id="learn-more">
-                <h3 class="text-iris"> Interested in learning more? </h3>
-                <p style="font-weight: 400;"> Learn more about Global Open Source Quality Assurance System (GOSQAS) by emailing us at 
-                    <span style="font-weight: 400;" class="text-decoration-underline text-iris"> gosqasystem@gmail.com</span> 
+        <h3 class="text-iris"> Interested in learning more? </h3>
+        <p style="font-weight: 400;"> Learn more about Global Open Source Quality Assurance System (GOSQAS) by emailing us at 
+        <span style="font-weight: 400;" class="text-decoration-underline text-iris"> gosqasystem@gmail.com</span> 
                     or visiting the links below.</p>
-                **buttons go here**  
-            </div>
+        <button-component buttonText="How It Works" color="#322253"
+            backgroundColor="#ffffff00"></button-component>                
+        <button-component buttonText="Data & Privacy" color="#322253"
+            backgroundColor="#ffffff00"></button-component>                
+        <button-component buttonText="GDT GitHub" color="#322253"
+            backgroundColor="#ffffff00"></button-component>
+    </div>
 
 </template>
 

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <span style="font-weight: 400;" class="text-decoration-underline text-iris"> gosqasystem@gmail.com</span> 
                     or visiting the links below.</p>
         <button-component buttonText="How It Works" color="#322253"
-            backgroundColor="#ffffff00"></button-component>                
+            backgroundColor="#ffffff00" onclick="window.location.href='how_it_works'"></button-component>                
         <button-component buttonText="Data & Privacy" color="#322253"
             backgroundColor="#ffffff00"></button-component>                
         <button-component buttonText="GDT GitHub" color="#322253"

--- a/packages/frontend/pages/about.vue
+++ b/packages/frontend/pages/about.vue
@@ -1,49 +1,72 @@
+<!-- about.vue
+Copyright (C) 2024 GOSQAS Team
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
+<!--
+    This is the About Us page for GOSQAS
+-->
+<script setup lang="ts">
+    const route = useRoute()
+</script>
+
+
 <template>
-    <link href='https://fonts.googleapis.com/css?family=Poppins' rel='stylesheet'>
-    <div class = "body1">
-        <h1>About Us</h1>
-The Global Open Source Quality Assurance System (GOSQAS) creates
-opportunities for better practices across the diverse humanitarian
-response, open-source hardware, and scientific research
-communities. We employ open-source tools and principles to centralize
-user solutions, despite location or resource environment.
+    <div class="container-fluid" id="about-container">
+        <h1 class="text-iris">About Us</h1>
+        <div class="row">
+            <p style="font-weight: 400; margin-bottom: 30px;" > The Global Open Source Quality Assurance System (GOSQAS) creates
+                opportunities for better practices across the diverse humanitarian
+                response, open-source hardware, and scientific research
+                communities. We employ open-source tools and principles to centralize
+                user solutions, despite location or resource environment. </p>
+    
+            <p> <span class="text-iris" style="font-weight:600">Our current products</span> <br>
+                Global Distributed Tracking - an open-source provenance tracker enabling closed-loop 
+                tracking for products, information, and logistics.</p>
+        </div>
 
-<h4>Our current products</h4>
+        <div class="row">
+            <h2 class="text-iris">Our Mission: Trust Through Transparency</h2>
+            <p>As an open-source organization, GOSQAS prioritizes transparency in all projects. Because we know that 
+                openness and clarity build trust and promote wide user adoption, our commitment to Trust Through Transparency 
+                (TTT) ensures our initiatives are enacted with integrity and accountability.</p>
+        </div>
 
-    As an open-source organization, GOSQAS prioritizes transparency in all
-projects. Because we know that openness and clarity build trust and
-promote wide user adoption, our commitment to Trust Through
-Transparency (TTT) ensures our initiatives are enacted with integrity
-and accountability.
+        <div class="row">
+            <h2 class="text-iris">Our Values</h2>
+            <p> <span class="text-iris" style="font-weight:600">Data Ownership</span> <br>
+                Users maintain full ownership of the data generated within the GOSQAS flagship product, Global Distributed Tracking. 
+                We do not have access to any user data, ensuring complete privacy and independent ownership.</p>
+            <p> <span class="text-iris" style="font-weight:600">Simplicity & Accessibility</span> <br>
+                All users, especially laypersons in limited resource environments, have access to GOSQAS projects. 
+                We believe that open-source projects should be simple to use and understand.</p>
+            <p> <span class="text-iris" style="font-weight:600">Open Source</span> <br>
+                Our projects are created for the public good and are available either free of charge or at minimal cost, 
+                reinforcing our dedication to community benefit and accessibility.</p>
+        </div>
 
-
-<h2>Our Values</h2>
-
-<h5>Data Ownership</h5>
-Users maintain full ownership of the data generated within the GOSQAS flagship product, Global Distributed Tracking. We do not have access to any user data, ensuring complete privacy and independent ownership.
-
-
-<h5>Simplicity & Accessibility</h5>
-All users, especially laypersons in limited resource environments, have access to GOSQAS projects. We believe that open-source projects should be simple to use and understand.
-
-<h5>Open Source</h5>
-Our projects are created for the public good and are available either free of charge or at minimal cost, reinforcing our dedication to community benefit and accessibility.
-<h4>Interested in learning more?</h4>
-Learn more about Global Distributed Tracking by emailing us at gosqasystem@gmail.com or visiting the links below.
-
- <div>
-
-    <button-component class="mt-3 mb-5 textToLinkButton0" buttonText="How It Works" color="#4e3681" backgroundColor="white"/>
-    <button-component class="mt-3 mb-5 textToLinkButton0" buttonText="Data & Privacy" margin="0px 0px 0px 20px" color="#4e3681" backgroundColor="white"/>
-    <button-component class="mt-3 mb-5 textToLinkButton0" buttonText="GDT GitHub" margin="0px 0px 0px 20px" color="#4e3681" backgroundColor="white"/>
+        <div class="row">
+            <Learn_more></Learn_more>
+        </div>
 
     </div>
-    </div>
+
 </template>
 
 
 <script lang="ts">
 import ButtonComponent from '~/components/ButtonComponent.vue';
+import Learn_more from '~/layouts/learn_more.vue';
 
 export default {
     components: {
@@ -52,38 +75,28 @@ export default {
 };
 </script>
 
-<style>
-body {
-    font-family: 'Poppins', sans-serif;
+<style scoped>
+
+/* For screens smaller than 768px */
+@media (max-width: 768px) {
+    #about-container{
+        padding: 20px 20px 40px 20px;
+    }
+    .row{
+        margin-top:32px;
+    }
+
 }
 
-div.body1 {
-    margin: 50px;
-}
-.navigationBar {
-    display: flex;
-    align-items: center;
-    padding-top: 7px;
-    background-color: #e6f6ff;
-}
-.logohomepage {
-    width: 60px;
-    margin: 20px 20px 20px 50px;
+/* For screens larger than 768px */
+@media (min-width: 768px) {
+    #about-container{
+        padding: 80px 200px 100px 200px;
+    }
+    .row{
+        margin-top:32px;
+    }
 }
 
-button.navigation {
-    background-color: transparent;
-    border-width: 0;
-    text-align: center;
-    margin: 0 10px;
-}
 
-.mainStuff {
-    margin: 50px;
-    margin-top: 30px;
-}
-.buttonSpacing {
-    display: flex;
-    column-gap: 20px;
-}
 </style>

--- a/packages/frontend/pages/about.vue
+++ b/packages/frontend/pages/about.vue
@@ -36,14 +36,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         </div>
 
         <div class="row">
-            <h2 class="text-iris">Our Mission: Trust Through Transparency</h2>
+            <h2 class="text-iris" id="subtitle">Our Mission: Trust Through Transparency</h2>
             <p>As an open-source organization, GOSQAS prioritizes transparency in all projects. Because we know that 
                 openness and clarity build trust and promote wide user adoption, our commitment to Trust Through Transparency 
                 (TTT) ensures our initiatives are enacted with integrity and accountability.</p>
         </div>
 
         <div class="row">
-            <h2 class="text-iris">Our Values</h2>
+            <h2 class="text-iris" id="subtitle">Our Values</h2>
             <p> <span class="text-iris" style="font-weight:600">Data Ownership</span> <br>
                 Users maintain full ownership of the data generated within the GOSQAS flagship product, Global Distributed Tracking. 
                 We do not have access to any user data, ensuring complete privacy and independent ownership.</p>
@@ -85,6 +85,10 @@ export default {
     .row{
         margin-top:32px;
     }
+    #subtitle{
+        margin-bottom:16px
+    }
+
 
 }
 
@@ -96,6 +100,10 @@ export default {
     .row{
         margin-top:32px;
     }
+    #subtitle{
+        margin-bottom:20px
+    }
+
 }
 
 

--- a/packages/frontend/pages/about.vue
+++ b/packages/frontend/pages/about.vue
@@ -55,9 +55,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 reinforcing our dedication to community benefit and accessibility.</p>
         </div>
 
-        <div class="row">
             <Learn_more></Learn_more>
-        </div>
 
     </div>
 

--- a/packages/frontend/pages/data_privacy.vue
+++ b/packages/frontend/pages/data_privacy.vue
@@ -21,13 +21,51 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 </script>
 
 <template>
-    This is the data and privacy pages
+    <div class="container-fluid" id="about-container">
+        <h1 class="text-iris">Data & Privacy</h1>
+        <div class="row"> <p>
+            Global Distributed Tracking encrypts user data and ensures its accessibility only 
+            through the unique device key, which is linked to a QR code. A cryptographic hash function 
+            securely references data via the device key. AES encryption with 128 bit keys is used along 
+            with SHA-256 for cryptographic hashing. This process is performed in a zero-knowledge manner, 
+            ensuring that the Global Distributed Tracking team never stores or knows a user device key. 
+            Only Global Distributed Tracking users and individuals with whom they share a device key have 
+            access to the History Record of a device.
+        </p> </div>
+    
+        <learn_more></learn_more>
 
-    <learn_more></learn_more>
+    </div>
 
 </template>
 
 <script lang="ts">
 import Learn_more from '~/layouts/learn_more.vue';
 </script>
+
+<style scoped>
+/* For screens smaller than 768px */
+@media (max-width: 768px) {
+    #about-container{
+        padding: 20px 20px 40px 20px;
+    }
+    .row{
+        margin-top:20px;
+    }
+
+
+}
+
+/* For screens larger than 768px */
+@media (min-width: 768px) {
+    #about-container{
+        padding: 80px 200px 100px 200px;
+    }
+    .row{
+        margin-top:32px;
+    }
+
+}
+
+</style>
 

--- a/packages/frontend/pages/data_privacy.vue
+++ b/packages/frontend/pages/data_privacy.vue
@@ -1,0 +1,33 @@
+<!-- home.vue
+Copyright (C) 2024 GOSQAS Team
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
+<!--
+    This is the home page for GOSQAS
+-->
+
+<script setup lang="ts">
+    const route = useRoute()
+</script>
+
+<template>
+    This is the data and privacy pages
+
+    <learn_more></learn_more>
+
+</template>
+
+<script lang="ts">
+import Learn_more from '~/layouts/learn_more.vue';
+</script>
+

--- a/packages/frontend/pages/home.vue
+++ b/packages/frontend/pages/home.vue
@@ -45,7 +45,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>
             </div>
             <div class="col" style="text-align: center; margin-top: 50px;">
-                <button-component buttonText="Learn more" color="#322253" 
+                <button-component buttonText="About Us" color="#322253" onclick="window.location.href='about'"
                     backgroundColor="#ffffff00"></button-component>
             </div>
 

--- a/packages/frontend/pages/home.vue
+++ b/packages/frontend/pages/home.vue
@@ -25,11 +25,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div class="row" id="first-row">
             <div class="col-12 col-md-7" id="first-row-col">
                 <div class="row"> <h1>Trust and transparancy when you need it most.</h1> </div>
-                <div class="row" style=" margin-bottom: 60px; margin-top:30px;">
-                    <div class="col">
-                        <button-component buttonText="Track an Asset" margin="0px 23px 0px 0px"></button-component>
+                <div class="row" style=" margin-bottom: 60px; margin-top:15px; ">
+                    <form class="col-lg-5" style="margin-bottom: 20px;" @submit.prevent="trackingForm">
+                        <button-component id="unclicked" buttonText="Track an Asset" type="submit" style="opacity:100;"></button-component>
+                    </form>
+                    <div class="col-lg-6" style="margin-bottom: 20px;">
                         <button-component buttonText="Create a Device" backgroundColor="#CCECFD" onclick="window.location.href='/'"
-                            borderColor="#CCECFD" color="#1E2019"></button-component>
+                            borderColor="#CCECFD" color="#1E2019" ></button-component>
+                    </div>
+                    <div id="trackAssetDiv" style="visibility: hidden;">
+                        <TrackAsset inputWidth="60%"></TrackAsset>
                     </div>
                 </div>
                 
@@ -60,9 +65,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 
 <script lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, type HtmlHTMLAttributes } from 'vue'
 import Learn_more from '~/layouts/learn_more.vue';
 import ButtonComponent from '~/components/ButtonComponent.vue';
+let showTrack = false;
 
 const second_row = [
     { title: "Simplicity & Accessibility", descr: "We belive that open-source projects should be simple to use and understand."},
@@ -70,6 +76,26 @@ const second_row = [
     { title: "Open Source", descr:"Our projects are created for the public good and are available either free of charge or at minimal cost."}
 ];
 
+export default {
+    methods: {
+        // Function to have the 'Track an asset' input field appear
+        async trackingForm() {
+            let trackAssetDiv = <HTMLDivElement>document.getElementById("trackAssetDiv");
+            let trackButton = <HTMLDivElement>document.getElementById("unclicked");
+
+            if (!showTrack) { //if showTrack is false
+                showTrack = true;
+                trackAssetDiv.style.visibility="visible"; //make text input available
+                trackButton.style.backgroundColor = "#322253";
+
+            } else { 
+                showTrack = false; 
+                trackAssetDiv.style.visibility="hidden";
+                trackButton.style.backgroundColor = "#4E3681";
+            }
+        },
+    }
+}
 
 </script>
 

--- a/packages/frontend/pages/home.vue
+++ b/packages/frontend/pages/home.vue
@@ -25,8 +25,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div class="row" id="first-row">
             <div class="col-12 col-md-7" id="first-row-col">
                 <div class="row"> <h1>Trust and transparancy when you need it most.</h1> </div>
-                <div class="row" style="padding: 18px 22px; margin-bottom: 60px;">
-                    **buttons go here**
+                <div class="row" style=" margin-bottom: 60px;">
+                    <div class="col">
+                        <button-component buttonText="Track an Asset"></button-component>
+                    </div>
+                    <div class="col">
+                        <button-component buttonText="Create a Device" backgroundColor="#CCECFD" 
+                            borderColor="#CCECFD" color="#1E2019"></button-component>
+                    </div>
                 </div>
                 
             </div>
@@ -41,7 +47,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>
             </div>
             <div class="row justify-content-center pt-3">
-                **This is where button goes.**
+                <button-component buttonText="Learn more" color="#322253"
+                    backgroundColor="#ffffff00"></button-component>
             </div>
         </div>
 
@@ -56,6 +63,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 <script lang="ts">
 import { ref, onMounted } from 'vue'
 import Learn_more from '~/layouts/learn_more.vue';
+import ButtonComponent from '~/components/ButtonComponent.vue';
 
 const second_row = [
     { title: "Simplicity & Accessibility", descr: "We belive that open-source projects should be simple to use and understand."},

--- a/packages/frontend/pages/home.vue
+++ b/packages/frontend/pages/home.vue
@@ -25,12 +25,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div class="row" id="first-row">
             <div class="col-12 col-md-7" id="first-row-col">
                 <div class="row"> <h1>Trust and transparancy when you need it most.</h1> </div>
-                <div class="row" style=" margin-bottom: 60px;">
+                <div class="row" style=" margin-bottom: 60px; margin-top:30px;">
                     <div class="col">
-                        <button-component buttonText="Track an Asset"></button-component>
-                    </div>
-                    <div class="col">
-                        <button-component buttonText="Create a Device" backgroundColor="#CCECFD" 
+                        <button-component buttonText="Track an Asset" margin="0px 23px 0px 0px"></button-component>
+                        <button-component buttonText="Create a Device" backgroundColor="#CCECFD" onclick="window.location.href='/'"
                             borderColor="#CCECFD" color="#1E2019"></button-component>
                     </div>
                 </div>
@@ -46,10 +44,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                     <p class="text-eggplant" style="font-weight: 400;">{{ item.descr }}</p>         
                 </div>
             </div>
-            <div class="row justify-content-center pt-3">
-                <button-component buttonText="Learn more" color="#322253"
+            <div class="col" style="text-align: center; margin-top: 50px;">
+                <button-component buttonText="Learn more" color="#322253" 
                     backgroundColor="#ffffff00"></button-component>
             </div>
+
         </div>
 
         <Learn_more  id="learn-more"></Learn_more>

--- a/packages/frontend/pages/home.vue
+++ b/packages/frontend/pages/home.vue
@@ -25,16 +25,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div class="row" id="first-row">
             <div class="col-12 col-md-7" id="first-row-col">
                 <div class="row"> <h1>Trust and transparancy when you need it most.</h1> </div>
-                <div class="row" style=" margin-bottom: 60px; margin-top:15px; ">
-                    <form class="col-lg-5" style="margin-bottom: 20px;" @submit.prevent="trackingForm">
-                        <button-component id="unclicked" buttonText="Track an Asset" type="submit" style="opacity:100;"></button-component>
+                <div class="row" style=" margin-bottom: 60px; margin-top:15px; display:inline-flex">
+                    <form style="margin-bottom: 20px; width:40%; min-width: 230px;" @submit.prevent="trackingForm">
+                        <button-component class="button" id="trackButton" buttonText="Track an Asset" type="submit" style="opacity:100;"
+                            padding="18px 22px"></button-component>
                     </form>
-                    <div class="col-lg-6" style="margin-bottom: 20px;">
-                        <button-component buttonText="Create a Device" backgroundColor="#CCECFD" onclick="window.location.href='/'"
-                            borderColor="#CCECFD" color="#1E2019" ></button-component>
+                    <div style="margin-bottom: 20px; width: 60%; min-width: 250px;" >
+                        <button-component class="button" buttonText="Create a Device" backgroundColor="#CCECFD" onclick="window.location.href='/'"
+                            borderColor="#CCECFD" color="#1E2019" padding="18px 22px"></button-component>
                     </div>
                     <div id="trackAssetDiv" style="visibility: hidden;">
-                        <TrackAsset inputWidth="60%"></TrackAsset>
+                        <TrackAsset inputWidth="53%"></TrackAsset>
                     </div>
                 </div>
                 
@@ -50,7 +51,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>
             </div>
             <div class="col" style="text-align: center; margin-top: 50px;">
-                <button-component buttonText="About Us" color="#322253" onclick="window.location.href='about'"
+                <button-component class="button" buttonText="About Us" color="#322253" onclick="window.location.href='about'"
                     backgroundColor="#ffffff00"></button-component>
             </div>
 
@@ -81,17 +82,19 @@ export default {
         // Function to have the 'Track an asset' input field appear
         async trackingForm() {
             let trackAssetDiv = <HTMLDivElement>document.getElementById("trackAssetDiv");
-            let trackButton = <HTMLDivElement>document.getElementById("unclicked");
+            let trackButton = <HTMLDivElement>document.getElementById("trackButton");
 
             if (!showTrack) { //if showTrack is false
                 showTrack = true;
                 trackAssetDiv.style.visibility="visible"; //make text input available
                 trackButton.style.backgroundColor = "#322253";
+                trackButton.style.borderColor = "#322253";
 
             } else { 
                 showTrack = false; 
                 trackAssetDiv.style.visibility="hidden";
                 trackButton.style.backgroundColor = "#4E3681";
+                trackButton.style.borderColor = "#4E3681";
             }
         },
     }
@@ -128,6 +131,9 @@ export default {
     #learn-more{
         padding: 40px 30px;
     }
+    .button{
+        font-size: 18px;
+    }
     
 }
 
@@ -144,6 +150,11 @@ export default {
     }
     #learn-more{
         padding: 70px 126px;
+    }
+    .button{
+        font-size: 20px;
+        padding: 1px;
+        
     }
 
 }


### PR DESCRIPTION
This is a very large PR that essentially styles the 'Home', 'About Us', 'How it Works' and 'Data & Privacy' pages. The specifics are listed below.

1. Fixes #244 : The previous PRs #234 and #226 created the 'How it Works' and 'Home' page. However, these did not contain buttons. In this PR, the buttons are added thanks to Ally's button component #243.
2. Fixes #201 : An 'About' page already existed from one of Nora's old PR. This page had most of the contents but did not have the latest design. In this PR, the 'About' page follows the latest Figma design.
3. Fixes #203 : A 'Data & Privacy' page was made in this PR following the latest Figma design.

Things missing or to fix:
1. The 'Home' page is still not our official home page, but I think once this PR is approved, then we can immediately make this the home page. To visit this 'Home' page, use `http://localhost:3000/home`

2. Sometimes when I click 'go back' on my browser, I am unable to see the page (see image below), but it works fine when  I reload it. This problem, however, ONLY happens in dev mode (with `npm run dev`) but not in production mode (`npm run preview`).
<img width="957" alt="image" src="https://github.com/user-attachments/assets/cd1d16a0-139d-49df-987c-295b1ed71dc3">
