### PR TITLE
'Download Image' and Long Words Issue in Provenance Feed

### DIFF
--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -39,9 +39,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             
             <div v-for="(attachment, i) in attachmentURLs[index.toString()]" :key="i">
                 <!-- Image -->
-                <img :src="attachment.url" :alt="Image" style="width: 150px; padding: 5px;" data-bs-toggle="modal" data-bs-target="#imageModal" @click="modalImage = attachment.url">
+                 <div v-if="((attachment.fileName).toLowerCase()).endsWith('.jpg') || ((attachment.fileName).toLowerCase()).endsWith('.png')  ">
+                    <img :src="attachment.url" :alt="Image" style="width: 150px; padding: 5px;" data-bs-toggle="modal" data-bs-target="#imageModal" @click="modalImage = attachment.url">
+                 </div>
                 <a :href="attachment.url" :download="attachment.fileName" style="display: block; padding: 5px; text-align: left;">
-                    Download Image
+                    Download File
                 </a>
             </div>
             

--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -127,6 +127,7 @@ export default {
   margin-bottom: 14px;
   border-radius: 20px;
   width: 70%; /* Assuming the width is to fill the container */
+  word-wrap: break-word;
 
 }
 .tag-container {


### PR DESCRIPTION
This PR fixes #255 and #254.

A single long word is now contained within the gray box and does not 'escape' out of it.

In addition, when a user uploads a file(s), the feed will show a preview and a link that says 'Download Image'. This link was changed to say 'Download File' so that users do not get confused when a PDF or any other non-image file is uploaded. The preview now is only available if users upload an image; they are unable to preview a non-image file. See image below.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/119ffcad-82e3-42fe-844b-496f55acb824">
