### PR TITLE
QR Code Download on Feed 

### DIFF
--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -41,7 +41,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 <!-- Image -->
                 <img :src="attachment.url" :alt="Image" style="width: 150px; padding: 5px;" data-bs-toggle="modal" data-bs-target="#imageModal" @click="modalImage = attachment.url">
                 <a :href="attachment.url" :download="attachment.fileName" style="display: block; padding: 5px; text-align: left;">
-                    Download File
+                    Download Image
                 </a>
             </div>
             

--- a/packages/frontend/components/QRCode.vue
+++ b/packages/frontend/components/QRCode.vue
@@ -23,7 +23,11 @@ import type QRCodeStyling from 'qr-code-styling';
 
 export default {
     props: {
-        url: {
+        size: {
+            type: Number,
+            default: 300
+        },
+        recordKey: {
             type: String,
             required: true
         }
@@ -33,9 +37,9 @@ export default {
             qrCode: null as HTMLElement | null,
             qrCodeStyling: null as QRCodeStyling | null,
             options: {
-                width: 322,
-                height: 361,
-                data: this.url,
+                width: this.size,
+                height: this.size,
+                data: this.getQrCodeUrl(),
                 imageOptions: {
                     hideBackgroundDots: true,
                     imageSize: 0.2,
@@ -53,7 +57,7 @@ export default {
                 cornersDotOptions: {
                     type: 'square' as 'square',  // Cast to specific type
                     color: '#4e3681'  // Color of the dot corners
-                }
+                },
             }
         };
     },
@@ -64,22 +68,37 @@ export default {
 
         if (this.qrCode) {
             this.qrCodeStyling.append(this.qrCode);
+        } else {
+            console.error('QR Code element not found');
+        }
+
+        // Add event listener to download QR Code on click
+        const canvas = this.qrCode?.querySelector('canvas');
+        canvas?.addEventListener('click', () => {
+            this.downloadQRCode();
+        });
+        // Show a pointer cursor on hover to indicate the QR Code is clickable
+        if (canvas) {
+            canvas.style.cursor = 'pointer';
         }
     },
-    watch: {
-        url(newValue: string | undefined) {
-            if (newValue) {
-                this.options.data = newValue;
-                this.qrCodeStyling?.update(this.options);
-            }
+    computed: {
+        qrCodeUrl() {
+            this.getQrCodeUrl();
         }
     },
     methods: {
         downloadQRCode() {
             this.qrCodeStyling?.download({
-                name: 'vqr',
+                name: this.recordKey,
                 extension: 'png'
             });
+        },
+        getQrCodeUrl() {
+            const baseUrl = useRuntimeConfig().public.frontendUrl;
+            const qrUrl = `${baseUrl}/provenance/${this.recordKey}`;
+            console.log('qrUrl', qrUrl);
+            return qrUrl;
         }
     }
 }

--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -1,59 +1,23 @@
 <template>
-    <button type="button" style="font-size: 18px;"class="btn mt-1 bg-sky px-5" v-on:click="downloadCSV">
+    <button type="button" class="btn mt-1 bg-sky px-5" v-on:click="downloadCSV">
         Download Children Keys as CSV
-    </button>&nbsp
-    <button style="font-size:18px;"class="btn mt-1 bg-sky px-5" @click="getQRCode">Download QR Code</button><br>
+    </button>
+
 </template>
 
 <script>
-import GenerateQRCode from '~/components/GenerateQRCode.vue';
-import KeyList from '~/components/KeyList.vue';
-import QRCodeStyling from "~/qrcode/src/core/QRCodeStyling";
+
 import { getChildrenKeys } from '~/utils/descendantList';
+
 export default {
-    components: {
-        GenerateQRCode,
-        KeyList,
-    },
     props: {
         recordKey: {
         type: String,
         required: true,
         },
     },
-    computed: {
-            qrCodeValue() {
-                return `http://localhost:3001/provenance/${this.deviceKey}`;
-            }
-    },
+
     methods: {
-        getQRCode() {
-                const qr = new QRCodeStyling({
-                    width: 322, 
-                    height: 361,
-                    data: this.qrCodeValue,
-                    imageOptions: {
-                    hideBackgroundDots: true,
-                    imageSize: 0.2,  // Image size as a fraction of the QR code size
-                    margin: 40,
-                    crossOrigin: 'Anonymous'
-                    },
-                    dotsOptions: {
-                    type: 'rounded',  // Rounded dots
-                    color: '#000000'  // Color of the dots
-                },
-                cornersSquareOptions: {
-                type: 'extra-rounded',  // Extra rounded corners for squares
-                color: '#000000'        // Color of the square corners
-                },
-                cornersDotOptions: {
-                type: 'extra-rounded',  // Extra rounded corners for dots
-                color: '#4e3681'        // Color of the dot corners
-                }
-                });
-            qr.download({ name: 'vqr', extension: 'png' });
-            console.log("downloadQRcode")
-        },
         async downloadCSV() {
             let keyList = await getChildrenKeys(this.recordKey);
             // Convert key to a link

--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -1,23 +1,59 @@
 <template>
-    <button type="button" class="btn mt-1 bg-sky px-5" v-on:click="downloadCSV">
+    <button type="button" style="font-size: 18px;"class="btn mt-1 bg-sky px-5" v-on:click="downloadCSV">
         Download Children Keys as CSV
-    </button>
-
+    </button>&nbsp
+    <button style="font-size:18px;"class="btn mt-1 bg-sky px-5" @click="getQRCode">Download QR Code</button><br>
 </template>
 
 <script>
-
+import GenerateQRCode from '~/components/GenerateQRCode.vue';
+import KeyList from '~/components/KeyList.vue';
+import QRCodeStyling from "~/qrcode/src/core/QRCodeStyling";
 import { getChildrenKeys } from '~/utils/descendantList';
-
 export default {
+    components: {
+        GenerateQRCode,
+        KeyList,
+    },
     props: {
         recordKey: {
         type: String,
         required: true,
         },
     },
-
+    computed: {
+            qrCodeValue() {
+                return `http://localhost:3001/provenance/${this.deviceKey}`;
+            }
+    },
     methods: {
+        getQRCode() {
+                const qr = new QRCodeStyling({
+                    width: 322, 
+                    height: 361,
+                    data: this.qrCodeValue,
+                    imageOptions: {
+                    hideBackgroundDots: true,
+                    imageSize: 0.2,  // Image size as a fraction of the QR code size
+                    margin: 40,
+                    crossOrigin: 'Anonymous'
+                    },
+                    dotsOptions: {
+                    type: 'rounded',  // Rounded dots
+                    color: '#000000'  // Color of the dots
+                },
+                cornersSquareOptions: {
+                type: 'extra-rounded',  // Extra rounded corners for squares
+                color: '#000000'        // Color of the square corners
+                },
+                cornersDotOptions: {
+                type: 'extra-rounded',  // Extra rounded corners for dots
+                color: '#4e3681'        // Color of the dot corners
+                }
+                });
+            qr.download({ name: 'vqr', extension: 'png' });
+            console.log("downloadQRcode")
+        },
         async downloadCSV() {
             let keyList = await getChildrenKeys(this.recordKey);
             // Convert key to a link

--- a/packages/frontend/pages/device/[deviceKey].vue
+++ b/packages/frontend/pages/device/[deviceKey].vue
@@ -122,7 +122,16 @@ export default {
             });
         }
     }
+    
 };
 
 
 </script>
+<style>
+#image-hover {
+
+}
+#image-hover:o {
+    color: gray;
+}
+</style>

--- a/packages/frontend/pages/device/[deviceKey].vue
+++ b/packages/frontend/pages/device/[deviceKey].vue
@@ -14,8 +14,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 <script setup lang="ts">
 const route = useRoute()
-const deviceKey = route.params.deviceKey;
-const qrCodeUrl = `${useRuntimeConfig().public.frontendUrl}/provenance/${deviceKey}`;
+const recordKey = route.params.deviceKey as string;
 </script>
 
 <template>
@@ -36,9 +35,7 @@ const qrCodeUrl = `${useRuntimeConfig().public.frontendUrl}/provenance/${deviceK
 
         </div>
         <div class="col-sm-6 col-lg-3 mt-2">
-
-            <QRCode :url="qrCodeUrl" ref="qrcode_component"/>
-
+            <QRCode :size=322 :recordKey="recordKey" ref="qrcode_component"/>
         </div>
 
     </div>

--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -102,7 +102,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>    
                 <CsvFile :recordKey="_recordKey"></CsvFile>
               </div>
-            </section><br>
+
+              <div>
+                <QRCode :size=200 :recordKey="_recordKey" ref="qrcode_component"/>
+              </div>
+            </section>
             
           </div>
           <!-- Spied element -->

--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -92,7 +92,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <section id="create-record">
               <ProvenanceCreateRecord :deviceRecord="deviceRecord" :recordKey="_recordKey"/>
             </section>
-            <section id="child-keys">
+            <section id="child-keys"><br>
               <div v-if="hasReportingKey"> Reporting Key:
                 <div> <a :href="`/provenance/${deviceRecord?.reportingKey}`">{{deviceRecord?.reportingKey}}</a></div>
               </div>
@@ -102,7 +102,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>    
                 <CsvFile :recordKey="_recordKey"></CsvFile>
               </div>
-            </section>
+            </section><br>
             
           </div>
           <!-- Spied element -->


### PR DESCRIPTION
I made it so that the user can just click the image of the QR code when they first make a device in order to download it. Then, when they get the main device asset history record feed page, next to download child keys as CSV button is the download the QR code button.

<img width="1512" alt="Screenshot 2024-10-03 at 5 54 21 PM" src="https://github.com/user-attachments/assets/fb5f1c36-96a1-46eb-aef3-3f453f072a3a">
<img width="1512" alt="Screenshot 2024-10-03 at 5 54 46 PM" src="https://github.com/user-attachments/assets/4d2a14e1-5e9c-40bf-8516-e254e94386fd">

To make it more clear for users, I plan on make there be a hover effect over the QR code that says "Click to download."
Here is an example:
![giphy](https://github.com/user-attachments/assets/fad8a8b4-e4a9-4495-91ff-429dcacfb9f2)
