### PR TITLE
Fix scrollspy hidden behind footer

### DIFF
--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -71,7 +71,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
         <div class="col-md-10">
           <!-- Spied element -->
-          <body  data-mdb-scrollspy-init data-spy="scroll" data-mdb-target="#jump-to" data-mdb-offset="0" class="left-col" >
+          <div  data-mdb-scrollspy-init data-spy="scroll" data-mdb-target="#jump-to" data-mdb-offset="0" class="left-col" >
             <section id="device-details">
               <div class="my-4 text-iris fs-1">"{{ deviceRecord.deviceName }}" Asset History Records</div>
               <div>Device ID: {{ deviceKey }}</div>
@@ -103,7 +103,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
               </div>
             </section>
             
-          </body>
+          </div>
           <!-- Spied element -->
         </div>
 
@@ -113,7 +113,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <div>
           <ProvenanceNotificationSignUpModal/>
       </div>   --> 
-
+      
     </div>
     <div v-else>
       <p>Device key not found.</p>


### PR DESCRIPTION
Changing the body tag to div tag fixes the rendering issues where the scrollspy is hidden behind the footer. There should only be one body tag.

![image](https://github.com/user-attachments/assets/59edf8d0-4f31-425b-bd2f-4e8187699559)
