### PR TITLE
Child keys not rendering correctly

### DIFF
--- a/packages/frontend/components/Provenance/PriorityNotices.vue
+++ b/packages/frontend/components/Provenance/PriorityNotices.vue
@@ -77,18 +77,19 @@ export default {
             }
         },
         refreshPage() {
-            console.log("XXXXXXXX");
             // set attachmentURLs to empty object to clear out old attachment URLs
             this.attachmentURLs = {};
+
+            if (!this.provenance) {
+              return;
+            }
+
             // First, we search for the high-priority notices;
             // at the time of this writing, recall is the only one.
-            console.log(this.provenance);
             this.notices = this.provenance.filter(
                 (p) => p.record.tags && p.record.tags.includes("recall"));
-            console.log("NOTICES",this.notices);
 
             this.notices.forEach((report, index) => this.fetchAttachmentsForReport(report, index));
-
         }
     },
 };
@@ -99,7 +100,7 @@ export default {
   background-color: red;
     }
 .report-box {
-    border: 5px solid #f00);
+    border: 5px solid #f00;
   padding: 20px;
   margin-bottom: 20px;
   border-radius: 5px;

--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -18,6 +18,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     their items.
     -->
 
+<script setup lang="ts">
+  const route = useRoute()
+  const deviceKey = route.params.deviceKey as string;
+</script>
+
 <template>
   <!-- This link is for the icon in mobile dropdown menu -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -69,9 +74,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           <!-- Spied element -->
           <body  data-mdb-scrollspy-init data-spy="scroll" data-mdb-target="#jump-to" data-mdb-offset="0" class="left-col" >
             <section id="device-details">
-              <div class="my-4 text-iris fs-1">"{{ deviceRecord.deviceName }}" Asset History Records</div>
+              <div class="my-4 text-iris fs-1">"{{ deviceRecord?.deviceName }}" Asset History Records</div>
               <div>Device ID: {{ deviceKey }}</div>
-              <div><span v-html="clickableLink(deviceRecord.description)"></span></div>
+              <div><span v-html="clickableLink(deviceRecord?.description)"></span></div>
             </section>
 
             <section ref= "section" id="priority-notices">
@@ -91,10 +96,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
               <div v-if="hasReportingKey"> Reporting Key:
                 <div> <a :href="`/provenance/${deviceRecord.reportingKey}`">{{deviceRecord.reportingKey}}</a></div>
               </div>
-              <div> Child Keys:
-                <div> <KeyList v-bind:keys="childKeys"/> </div>
-              </div>
               <div v-if="(childKeys.length > 0) || hasReportingKey ">
+                <div> Child Keys:
+                  <div> <KeyList v-bind:keys="childKeys"/> </div>
+                </div>    
                 <CsvFile :deviceKey="deviceKey"></CsvFile>
               </div>
             </section>
@@ -180,6 +185,9 @@ export default {
         // Decompose the provenance records into parts to be rendered.
         ({ provenanceNoRecord, deviceCreationRecord, deviceRecord } = decomposeProvenance(provenance));
         
+        // console.log("provenanceNoRecord", provenanceNoRecord)
+        // console.log("deviceCreationRecord", deviceCreationRecord)
+        console.log("deviceRecord", deviceRecord)
         this.isLoading = false;
 
         // This functionality could be pushed into a component...

--- a/packages/frontend/pages/provenance/[deviceKey].vue
+++ b/packages/frontend/pages/provenance/[deviceKey].vue
@@ -94,7 +94,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             </section>
             <section id="child-keys">
               <div v-if="hasReportingKey"> Reporting Key:
-                <div> <a :href="`/provenance/${deviceRecord.reportingKey}`">{{deviceRecord.reportingKey}}</a></div>
+                <div> <a :href="`/provenance/${deviceRecord?.reportingKey}`">{{deviceRecord?.reportingKey}}</a></div>
               </div>
               <div v-if="(childKeys.length > 0) || hasReportingKey ">
                 <div> Child Keys:
@@ -185,9 +185,6 @@ export default {
         // Decompose the provenance records into parts to be rendered.
         ({ provenanceNoRecord, deviceCreationRecord, deviceRecord } = decomposeProvenance(provenance));
         
-        // console.log("provenanceNoRecord", provenanceNoRecord)
-        // console.log("deviceCreationRecord", deviceCreationRecord)
-        console.log("deviceRecord", deviceRecord)
         this.isLoading = false;
 
         // This functionality could be pushed into a component...

--- a/packages/frontend/test/data/provenance.ts
+++ b/packages/frontend/test/data/provenance.ts
@@ -97,7 +97,7 @@ export const fakeProvenanceWithChildren = [
                 "customer"
             ],
             "children_key": ["childkey2", "childkey3"],
-            "children_name": ["abc"], // What happens if these don't match?
+            "children_name": ["abc", "def"],
             "warnings": [],
             "isRecall": false
         },

--- a/packages/frontend/test/data/provenance.ts
+++ b/packages/frontend/test/data/provenance.ts
@@ -1,0 +1,143 @@
+// Example of real data
+export const fakeProvenanceNoChildren = [
+    {
+        "record": {
+            "description": "Distributed to user.",
+            "tags": [
+                "distribution",
+            ],
+            "children_key": [],
+            "children_name": [],
+            "warnings": [],
+            "isRecall": false
+        },
+        "attachments": [
+            "9s8d7f98sfd"
+        ],
+        "deviceID": "abc123",
+        "timestamp": 1720000000005
+    },
+    {
+        "record": {
+            "description": "Training session",
+            "tags": [
+                "training",
+                "customer"
+            ],
+            "children_key": [],
+            "children_name": [],
+            "warnings": [],
+            "isRecall": false
+        },
+        "attachments": [
+            "9s8d7f98sfd"
+        ],
+        "deviceID": "abc123",
+        "timestamp": 1720000000004
+    },
+    {
+        "record": {
+            "description": "Reading for shipping.",
+            "tags": []
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000003
+    },
+    {
+        "record": {
+            "description": "Quality Assurance",
+            "tags": [
+                "qa"
+            ]
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000002
+    },
+    {
+        "record": {
+            "description": "Some description",
+            "name": "Some name",
+            "tags": [
+                "created"
+            ],
+            "deviceName": "Some deviceName"
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000001
+    }
+]
+
+// Example of real data
+export const fakeProvenanceWithChildren = [
+    {
+        "record": {
+            "description": "Distributed to user.",
+            "tags": [
+                "distribution",
+            ],
+            "children_key": ["childkey1"],
+            "children_name": ["xyz"],
+            "warnings": [],
+            "isRecall": false
+        },
+        "attachments": [
+            "9s8d7f98sfd"
+        ],
+        "deviceID": "abc123",
+        "timestamp": 1720000000005
+    },
+    {
+        "record": {
+            "description": "Training session",
+            "tags": [
+                "training",
+                "customer"
+            ],
+            "children_key": ["childkey2", "childkey3"],
+            "children_name": ["abc"], // What happens if these don't match?
+            "warnings": [],
+            "isRecall": false
+        },
+        "attachments": [
+            "9s8d7f98sfd"
+        ],
+        "deviceID": "abc123",
+        "timestamp": 1720000000004
+    },
+    {
+        "record": {
+            "description": "Reading for shipping.",
+            "tags": []
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000003
+    },
+    {
+        "record": {
+            "description": "Quality Assurance",
+            "tags": [
+                "qa"
+            ]
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000002
+    },
+    {
+        "record": {
+            "description": "Some description",
+            "name": "Some name",
+            "tags": [
+                "created"
+            ],
+            "deviceName": "Some deviceName"
+        },
+        "attachments": [],
+        "deviceID": "abc123",
+        "timestamp": 1720000000001
+    }
+]

--- a/packages/frontend/utils/descendantList.spec.ts
+++ b/packages/frontend/utils/descendantList.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getChildKeys } from './descendantList';
+import { fakeProvenanceNoChildren, fakeProvenanceWithChildren } from '~/test/data/provenance';
+
+describe('descendantList', () => {
+    it('should return an empty list of keys', async () => {
+        const keys = getChildKeys(fakeProvenanceNoChildren)
+        expect(keys).toEqual([]);
+    });
+
+    it('should return an list of child keys', async () => {
+        const keys = getChildKeys(fakeProvenanceWithChildren)
+        const expected = [
+            ["childkey1"],
+            ["childkey2", "childkey3"]
+        ];
+        expect(keys).toEqual(expected);
+    });
+});

--- a/packages/frontend/utils/descendantList.ts
+++ b/packages/frontend/utils/descendantList.ts
@@ -3,24 +3,12 @@
 // or the list of direct descendants (children only) given a key 
 
 import { getProvenance } from '~/services/azureFuncs';
-
+import type { Provenance } from '~/utils/types';
 
 // gets all children given a key
 export async function getChildrenKeys(key: string) {
-
-    let childKeysList:string = "";
-
     const response = await getProvenance(key);
-    for (let i=0; i < response.length; i++) {
-
-        childKeysList += response[i].record.children_key + ",";
-    }
-
-    let newChildKeysList = childKeysList.split(',');
-
-    newChildKeysList = newChildKeysList.filter(c => String(c).trim()); // filter out if key = ""
-
-    return newChildKeysList;
+    return getChildKeys(response);
 }
 
 // Gets all descendants given a key
@@ -33,4 +21,31 @@ export async function getAllDescendants(key: string) {
     }
 
     return children_list;
+}
+
+
+export function decomposeProvenance(provenance: Provenance[]) {
+    // Decompose the provenance array into the first entry and the remaining entries.
+
+    const provenanceNoRecord = provenance.slice(0, -1); // get the provenance without device creation
+    const deviceCreationRecord = [provenance.at(-1)]; // the last record in the list should be the device creation
+    const deviceRecord = provenance[provenance.length - 1].record; // subset of the record for rendering
+
+    return { provenanceNoRecord, deviceCreationRecord, deviceRecord };
+}
+
+
+export function getChildKeys(provenance: Provenance[]): string[] {
+    let childKeys: string[] = []
+
+    for (const p of provenance) {
+        const child = p.record.children_key;
+        // child may be undefined or an empty array
+        if (!child || !child.length) {
+            continue;
+        }
+        childKeys.push(p.record.children_key)
+    }
+
+    return childKeys;
 }

--- a/packages/frontend/utils/types.ts
+++ b/packages/frontend/utils/types.ts
@@ -1,0 +1,22 @@
+// types.ts - Defines common application types
+
+// Copyright (C) 2024 GOSQAS Team
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface Provenance {
+    record: any;
+    attachments?: string[];
+    deviceID?: string;
+    timestamp: number;
+}


### PR DESCRIPTION
Child keys are rendering as "undefined". From real data it was observed that the child key can be undefined or [].

The root cause is the search for the child key isn't checking for both cases.

The code is moved into helper functions that can be unit tested against a real example of the provenance data structure (with fake data).
