### PR TITLE
The "Notify all Children?" checkbox is hidden when creating a new device

### DIFF
--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -42,8 +42,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div>
             <span v-for="(tag, index) in tags" :key="tag">{{ tag }}{{ index !== tags.length - 1 ? ', ' : '' }} </span>
         </div>
-        <h5 class="text-iris">
-            <input type="checkbox" class="form-check-input" id="notify-all"/> Notify all Children?
+        <h5 class="text-iris p-1 mt-0" v-if="!hasParent"> <!--This checks whether it is a container or device and decides whether or not to display this.-->
+            <input type="checkbox" class="form-check-input" id="notify-all" /> Notify all Children?
         </h5>
     </div>
     <div class="d-grid" id="submit-button">
@@ -68,10 +68,11 @@ export default {
             tags: [] as string[],
             containerKey: '',
             childrenKey: [] as string[],
-            hasParent: false,
+            hasParent: this.isContainer ? false : true,
             isReportingKey: false,
         }
     },
+
     props: {
         deviceKey: {
             type: String,


### PR DESCRIPTION
When you make a container, should the reporting keys have the "Notify all children" checkbox or not? I hid the "Notify all children" checkbox for when a user creates a device:
<img width="1512" alt="Screenshot 2024-10-13 at 7 05 57 PM" src="https://github.com/user-attachments/assets/8b1acd58-b76e-430c-b7ef-184f3c3e0e9d">

When you create a new container it does appear again:
<img width="1512" alt="Screenshot 2024-10-13 at 7 05 07 PM" src="https://github.com/user-attachments/assets/263b294d-1afe-462c-87a5-0810b4de535e">

However, it also appears for a container's reporting key and child keys:
<img width="1512" alt="Screenshot 2024-10-13 at 7 05 13 PM" src="https://github.com/user-attachments/assets/712b1ca8-4024-4153-a800-d68da499cd31">