### PR TITLE
Allowed users to enter a device key or a URL to view a record

### DIFF
--- a/packages/frontend/components/TrackAsset.vue
+++ b/packages/frontend/components/TrackAsset.vue
@@ -43,7 +43,9 @@ export default {
     },
     methods: {
         async submit() {
-            this.$router.push({ path: `/provenance/${this.deviceKey}` });
+            // Get the record/device key from the end of an entered URL, or just use the entered key
+            var extractedDeviceKey = this.deviceKey.split("/").pop();
+            this.$router.push({ path: `/provenance/${extractedDeviceKey}` });
         }
     }
 }


### PR DESCRIPTION
The track asset field now accepts both URLs and record keys. I didn't change the default text on the track asset field from 'Device key' since that's what it says on the FIGMA, but I can if desired.