### PR TITLE
Adding Provenance CSV

### DIFF
--- a/packages/frontend/components/Provenance/ProvenanceCSV.vue
+++ b/packages/frontend/components/Provenance/ProvenanceCSV.vue
@@ -31,7 +31,6 @@ export default {
                 // Create CSV header
                 let csvContent = 'Timestamp,Description,Device Name,Tags,Children Names,Children Keys,Attachment File\n';
 
-                // Use for...of instead of forEach for async operations
                 for (const provenanceItem of provenanceData) {
                     // Format timestamp in UTC with both local and UTC time
                     const date = new Date(provenanceItem.record.timestamp || provenanceItem.timestamp);
@@ -39,6 +38,7 @@ export default {
                     const utcTime = date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
                     const timestamp = `${localTime} (${utcTime})`;
 
+                    //Format Description and Device Name
                     const description = provenanceItem.record?.description?.replace(/"/g, '""') || '';
                     const deviceName = provenanceItem.record?.deviceName?.replace(/"/g, '""') || '';
 
@@ -48,12 +48,14 @@ export default {
                         .join(';');
                     const formattedTags = `[${tags}]`;
 
+                    //Find Children Names and format them
                     const children = (provenanceItem.record?.children_name || [])
                         .map(tag => `"${tag.replace(/"/g, "''")}"`)
                         .join(';');
 
                     const childrenNames = `[${children}]`
 
+                     //Find Children Keys and format them
                     const childrenKeys = (provenanceItem.record?.children_key || [])
                         .map(tag => `"${tag.replace(/"/g, "''")}"`)
                         .join(';');
@@ -75,7 +77,8 @@ export default {
                     const attachmentName = await Promise.all(attachmentPromises);
                     const stringifyAttachmentName = attachmentName
                         .map(name => `"${name.replace(/"/g, '""')}"`);    
-
+                    
+                    // Concatenate relevant data for csv file
                     csvContent += `${timestamp},${description},${deviceName},${formattedTags},${childrenNames},${formattedChildrenKeys},${stringifyAttachmentName}\n`;
                 }
 

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -119,6 +119,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 </div>    
                 <CsvFile :recordKey="_recordKey"></CsvFile>
               </div>
+              <ProvenanceCSV :recordKey="_recordKey"></ProvenanceCSV>
             </section>
             
           </div>

--- a/packages/frontend/pages/record/[deviceKey].vue
+++ b/packages/frontend/pages/record/[deviceKey].vue
@@ -48,6 +48,7 @@ const qrCodeUrl = `${useRuntimeConfig().public.frontendUrl}/history/${recordKey}
         </div>
         <CsvFile :recordKey="_recordKey"></CsvFile>
     </div>
+    <ProvenanceCSV :recordKey="_recordKey"></ProvenanceCSV>
   </div>
 </template>
 <script lang="ts">


### PR DESCRIPTION
This PR gives users the permission to download the provenance records. The provenance's Timestamp, Description, Device Name, Tags, Children Names, Children Keys, Attachment File are available to download via a csv file named `provenance_[deviceKey].csv and the respected headers separated by commas.

The Timestamp is converted to UTC datetime. The Description and Device Name are strings. The Tags, Children Names and Children Keys, if any are present, are stored in an array with each element separated by a semi-colon. The Attachment File is also a string which is the name of the attached file, if provided.

For empty fields, the empty string is used. 

The following is an example of the csv file of a provenance:
![Screenshot 2025-04-21 185750](https://github.com/user-attachments/assets/7e180d70-549c-4a8d-9969-58c27b453d6f)

The corresponding issue for this is #211 
