### PR TITLE
added versioning endpoint to return the version, git commit and build…

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,8 @@
     "prestart": "npm run clean && npm run build",
     "start": "func start",
     "test": "ts-node ./test/test.ts",
-    "dev": "func start",
+    "dev": "npm run update-version && func start",
+    "update-version": "node --loader ts-node/esm scripts/updateVersion.ts",
     "vitest": "vitest",
     "coverage": "vitest run --coverage"
   },

--- a/packages/backend/scripts/updateVersion.ts
+++ b/packages/backend/scripts/updateVersion.ts
@@ -1,0 +1,98 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { VersionInfo, VERSION_INFO } from '../src/version.js';
+
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function incrementVersion(version: string): string {
+    // Increment the patch version by 1
+    const versionArr = version.split('.');
+    
+    if (versionArr.length !== 3) {
+        throw new Error(`Invalid version format: ${version}. Expected format is x.y.z`);
+    }
+    
+    // Clean up the patch version by removing any suffix
+    const patchWithSuffix = versionArr[2];
+    let patch = 0;
+    if (versionArr[2].includes('-')){
+        patch = parseInt(patchWithSuffix.split('-')[0]);
+    }
+    else{
+        patch = parseInt(patchWithSuffix);
+    }
+    
+    const patchNumber = patch
+    const major = parseInt(versionArr[0]);
+    const minor = parseInt(versionArr[1]);
+    
+    if (isNaN(major) || isNaN(minor) || isNaN(patchNumber)) {
+        throw new Error(`Invalid version numbers: ${version}. Expected format is x.y.z`);
+    }
+    
+    const newPatch = patchNumber + 1;
+    return `${major}.${minor}.${newPatch}`;
+}
+
+function getCurrentVersion(): string {
+    // Read the current version from package.json
+    const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
+    return packageJson.version || '0.0.0';
+}
+
+function getGitCommitHash(): string {
+    // Get the short hash of the current git commit
+    try {
+        return execSync('git rev-parse --short HEAD').toString().trim();
+    } catch (error) {
+        console.warn('Unable to get git commit hash:', error);
+        return 'unknown';
+    }
+}
+
+function generateVersionInfo(): VersionInfo {
+    // Get the current version from package.json
+    // Return the updated version info object
+    const currentVersion = getCurrentVersion();
+    const newVersion = incrementVersion(currentVersion);
+    const buildTime = new Date().toISOString();
+    
+    const versionInfo: VersionInfo = {
+        version: newVersion,
+        gitCommit: getGitCommitHash(),
+        buildTime: buildTime
+    };
+
+    return versionInfo;
+}
+
+function updateVersion() {
+    const versionInfo = generateVersionInfo();
+    const versionPath = path.join(__dirname, '..', 'src', 'version.ts');
+    
+    // Read existing file content
+    const existingContent = fs.readFileSync(versionPath, 'utf-8');
+    
+    // Replace only the VERSION_INFO constant while preserving interface
+    const updatedContent = existingContent.replace(
+        /export const VERSION_INFO: VersionInfo = {[\s\S]*?};/m,
+        `export const VERSION_INFO: VersionInfo = ${JSON.stringify(versionInfo, null, 2)};`
+    );
+    
+    // Write back to file
+    fs.writeFileSync(versionPath, updatedContent, 'utf-8');
+    
+    // Update package.json version
+    const packageJsonPath = path.join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    packageJson.version = versionInfo.version;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    
+    console.log(`Version updated to ${versionInfo.version}`);
+}
+
+updateVersion();

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -3,7 +3,8 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/fu
 import { BlockBlobClient, ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob";
 import bs58 from 'bs58';
 import JSON5 from 'json5';
-
+import { execSync } from 'child_process';
+import { VERSION_INFO } from '../version.js';
 
 // To deploy this project from the command line, you need:
 //  * Azure CLI : https://learn.microsoft.com/en-us/cli/azure/
@@ -12,6 +13,8 @@ import JSON5 from 'json5';
 // Once you've logged into Azure via 'az login' to an Azure account w/ PubInv permissions,
 // you deploy this function project via this command:
 //  > func azure functionapp publish gosqasbe
+
+
 
 interface ProvenanceRecord {
     record: any,
@@ -374,6 +377,14 @@ async function getStatistics(request: HttpRequest, context: InvocationContext): 
     };
 };
 
+export async function getVersion(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    // This is a simple function that returns the version of the server.
+    return { 
+        jsonBody: VERSION_INFO,
+        headers: { "Content-Type": "application/json" }
+    };
+}
+
 app.get("getProvenance", {
     authLevel: 'anonymous',
     route: 'provenance/{deviceKey}',
@@ -408,6 +419,12 @@ app.get("getStatistics", {
     authLevel: 'anonymous',
     route: 'statistics',
     handler: getStatistics
+})
+
+app.get("getVersion", {
+    authLevel: 'anonymous',
+    route: 'version',
+    handler: getVersion
 })
 
 

--- a/packages/backend/src/version.ts
+++ b/packages/backend/src/version.ts
@@ -1,0 +1,11 @@
+export interface VersionInfo {
+    version: string;
+    gitCommit: string;
+    buildTime: string;
+}
+export const VERSION_INFO: VersionInfo = {
+    // This is a placeholder and should be replaced by the updateVersion script
+    version: "1.0.0",
+    gitCommit: "unknown",
+    buildTime: new Date().toISOString()
+};


### PR DESCRIPTION
This returns the backend version via the API endpoint. The related issue is #433. 
Created an interface for the data (i.e., version, git commit, build time) that needs to be returned through the endpoint in versions.ts file. Created the endpoint by extending the httpsTrigger file and the updateVersion script to be run at buildTime and update the versionInfo fields. 

Updated the package.json file to run the update-version script, i.e. the updateVersion script.

To test versioning changing automatically can run: `npm run update-version`. This runs the `updateVersion` script but it changes the version in the `package.json` automatically. This is the following when the `http://localhost:7071/api/version` opened when running the backend:
![Screenshot 2025-05-07 214659](https://github.com/user-attachments/assets/a4f5dc07-389b-49a0-9a4e-c528058d4cda)

N.B.: Curious about the value limit of each number in the version, i.e. `x.y.z` should each number in the version string have a limit?