### PR TITLE
Changed Email on Website to "info@gosqas.org"

### DIFF
--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -339,7 +339,7 @@ export default {
 /* Light mode version*/
 @media (prefers-color-scheme: light) {
     #record-form {
-        background-color: #CCECFD;
+        background-color: #E6F6FF;
     }
     h4 {
         color: #4E3681;

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     <div class="row" id="learn-more">
         <h2> Interested in learning more? </h2>
         <p class ="mb-0" style="font-weight: 400;"> Learn more about Global Open Source Quality Assurance System (GOSQAS) by emailing us at 
-            <span class="learn-more-desc text-decoration-underline" id="p-text"> info@gosqas.org</span> 
+            <a class="learn-more-desc" href="mailto:info@gosqas.org">info@gosqas.org</a> 
                     or visiting the links below.</p>
         <div>
             <RouterLink to="/how-it-works"><button class="baseButton button first learn-more" id="learn-more-button" style="
@@ -75,6 +75,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         font-weight: 400;
         overflow-wrap: break-word;
     }
+
+@media (min-width: 768px) {
+    .learn-more-desc {
+        font-size: 20px;
+        line-height: 30px;
+    }
+}
 
 /* Dark mode version*/
 @media (prefers-color-scheme: dark) {

--- a/packages/frontend/layouts/learn_more.vue
+++ b/packages/frontend/layouts/learn_more.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     <div class="row" id="learn-more">
         <h2> Interested in learning more? </h2>
         <p class ="mb-0" style="font-weight: 400;"> Learn more about Global Open Source Quality Assurance System (GOSQAS) by emailing us at 
-            <span class="learn-more-desc text-decoration-underline" id="p-text"> gosqasystem@gmail.com</span> 
+            <span class="learn-more-desc text-decoration-underline" id="p-text"> info@gosqas.org</span> 
                     or visiting the links below.</p>
         <div>
             <RouterLink to="/how-it-works"><button class="baseButton button first learn-more" id="learn-more-button" style="

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -165,10 +165,7 @@ const qrCodeUrl = `${useRuntimeConfig().public.frontendUrl}/history/${recordKey}
   <p class="error-description">
     We’re sorry, the record you’re looking for could not be found. <br />
     Please double-check your key. If you keep receiving this error, <br />
-    email us at
-    <span class="error-email">
-      info@gosqas.org
-    </span>.
+    email us at <a class="error-email" href="mailto:info@gosqas.org">info@gosqas.org</a>.
   </p>
   <div class="error-buttons">
     <!-- Go home button -->
@@ -546,11 +543,10 @@ a:visited {
 
 .error-email {
   font-family: 'Poppins', sans-serif;
-  font-weight: 500;
   font-size: 20px;
   line-height: 30px;
   color: #4e3681;
-  text-decoration: underline;
+  text-decoration: underline !important;
 }
 
 .error-buttons {

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -167,14 +167,14 @@ const qrCodeUrl = `${useRuntimeConfig().public.frontendUrl}/history/${recordKey}
     Please double-check your key. If you keep receiving this error, <br />
     email us at
     <span class="error-email">
-      gosqasystem@gmail.com
+      info@gosqas.org
     </span>.
   </p>
   <div class="error-buttons">
     <!-- Go home button -->
-    <RouterLink to="/" class="btn btn-primary">Go home</RouterLink>
+    <RouterLink to="/" class="btn btn-primary error-button">Go home</RouterLink>
     <!-- Email us button -->
-    <RouterLink to="/contact" class="btn btn-secondary">Email us</RouterLink>
+    <RouterLink to="/contact" class="btn btn-secondary error-button">Email us</RouterLink>
   </div>
 </div>
 </div>
@@ -555,9 +555,13 @@ a:visited {
 
 .error-buttons {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   gap: 20px;
   margin-top: 20px;
+}
+
+.error-button {
+  width: 48% !important;
 }
 
 .btn {

--- a/packages/frontend/pages/terms_and_conditions.vue
+++ b/packages/frontend/pages/terms_and_conditions.vue
@@ -30,7 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 We are the Global Open Source Quality Assurance System “GOSQAS.” We operate the website 
                 <a href="https://gosqas.org">https://gosqas.org</a>. You can contact us by email at 
                 <span style="font-weight: 400;" class="text-decoration-underline"> 
-                gosqasystem@gmail.com</span>.<br><br>
+                info@gosqas.org</span>.<br><br>
 
                 These Legal Terms constitute a legally binding agreement made between you, whether 
                 personally or on behalf of an entity ("you"), and Global Open Source Quality Assurance 
@@ -159,7 +159,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <p>
                 In order to resolve a complaint regarding the Services or to receive further information regarding 
                 use of the Services, please contact us at <span style="font-weight: 400;" 
-                class="text-decoration-underline"> gosqasystem@gmail.com</span>.
+                class="text-decoration-underline"> info@gosqas.org</span>.
             </p>
         </div>
 

--- a/packages/frontend/pages/terms_and_conditions.vue
+++ b/packages/frontend/pages/terms_and_conditions.vue
@@ -28,9 +28,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <h3 id="subtitle">Agreement to Our Legal Terms</h3>
             <p style="margin-bottom:32px;">
                 We are the Global Open Source Quality Assurance System “GOSQAS.” We operate the website 
-                <a href="https://gosqas.org">https://gosqas.org</a>. You can contact us by email at 
-                <span style="font-weight: 400;" class="text-decoration-underline"> 
-                info@gosqas.org</span>.<br><br>
+                <a class="link-font" href="https://gosqas.org">https://gosqas.org</a>. You can contact us by email at 
+                <a class="link-font" href="mailto:info@gosqas.org">info@gosqas.org</a>.<br><br>
 
                 These Legal Terms constitute a legally binding agreement made between you, whether 
                 personally or on behalf of an entity ("you"), and Global Open Source Quality Assurance 
@@ -158,8 +157,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <h3 id="subtitle">Contact Us</h3>
             <p>
                 In order to resolve a complaint regarding the Services or to receive further information regarding 
-                use of the Services, please contact us at <span style="font-weight: 400;" 
-                class="text-decoration-underline"> info@gosqas.org</span>.
+                use of the Services, please contact us at <a class="link-font" href="mailto:info@gosqas.org">info@gosqas.org</a>.
             </p>
         </div>
 
@@ -189,6 +187,10 @@ a {
     #terms-and-conditions-container{
         padding: 80px 200px 100px 200px;
     } 
+    .link-font {
+        font-size: 20px;
+        line-height: 30px;
+    }
 }
 
 /* Dark mode version*/


### PR DESCRIPTION
Changed the email to the new gosqas email and converted the email on the site to links (that open an empty email to info@gosqas.org).