### PR TITLE
updated the provenance and children csvs in accordance to Rob's desired outline

### DIFF
--- a/packages/frontend/components/Provenance/ProvenanceCSV.vue
+++ b/packages/frontend/components/Provenance/ProvenanceCSV.vue
@@ -29,7 +29,7 @@ export default {
                 }
 
                 // Create CSV header
-                let csvContent = 'Timestamp,Description,Device Name,Tags,Children Names,Children Keys,Attachment File\n';
+                let csvContent = 'Timestamp,Device Name,Device Key,Device Url,Description,Tags,Reporting Key,Attachment File\n';
 
                 for (const provenanceItem of provenanceData) {
                     // Format timestamp in UTC with both local and UTC time
@@ -48,19 +48,8 @@ export default {
                         .join(';');
                     const formattedTags = `[${tags}]`;
 
-                    //Find Children Names and format them
-                    const children = (provenanceItem.record?.children_name || [])
-                        .map(tag => `"${tag.replace(/"/g, "''")}"`)
-                        .join(';');
-
-                    const childrenNames = `[${children}]`
-
-                    //Find Children Keys and format them
-                    const childrenKeys = (provenanceItem.record?.children_key || [])
-                        .map(tag => `"${tag.replace(/"/g, "''")}"`)
-                        .join(';');
-
-                    const formattedChildrenKeys = `[${childrenKeys}]`
+                    //Get reporting key
+                    const reportingKey = provenanceItem.record?.reportingKey?.replace(/"/g, '""') || '';
 
                     // Get attachment filename
                     const baseUrl = useRuntimeConfig().public.baseUrl;
@@ -73,13 +62,16 @@ export default {
                             return attachmentId;
                         }
                     });
-
                     const attachmentName = await Promise.all(attachmentPromises);
                     const stringifyAttachmentName = attachmentName
                         .map(name => `"${name.replace(/"/g, '""')}"`);
+                    
+                    //Stores device url and device key
+                    const deviceUrl = (window.location.origin + this.$route.fullPath).replace(/,+$/, '');
+                    const deviceKey = this.recordKey;
 
                     // Concatenate relevant data for csv file
-                    csvContent += `${timestamp},${description},${deviceName},${formattedTags},${childrenNames},${formattedChildrenKeys},${stringifyAttachmentName}\n`;
+                    csvContent += `"${timestamp}","${deviceName}","${deviceKey}","${deviceUrl}","${description}","${formattedTags}","${reportingKey}","${stringifyAttachmentName}"\n`;
                 }
 
                 // Create and trigger download

--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -27,12 +27,15 @@ export default {
                 const reportingRecord = reportingProvenance?.[0]?.record;
                 const reportingKey = reportingRecord?.children_key?.[0] || reportingRecord?.reportingKey || '';
 
+                const parentUrl = (window.location.origin + this.$route.fullPath).replace(/,+$/, '');
+                const parentName = reportingRecord.deviceName?.replace(/"/g, '""') || '';
+
                 // Skip the parent
                 const filteredChildrenKeys = childrenKeys.filter(key =>
                     key !== this.recordKey && key !== reportingKey
                 );
 
-                const csvRows = [['Child Name', 'Parent Record Key', 'Reporting Key', 'Child Key URL']];
+                const csvRows = [['Parent Record Key', 'Parent URL', 'Parent Device Name', 'Reporting Key', 'Child Name', 'Child Key', 'Child Key URL']];
 
                 for (const childKey of filteredChildrenKeys) {
 
@@ -40,12 +43,15 @@ export default {
                     const record = provenanceList?.[0]?.record || {};
 
                     const childName = record.deviceName || '';
-                    const childUrl = `${useRuntimeConfig().public.frontendUrl}/history/{childKey}`
+                    const childUrl = `${useRuntimeConfig().public.frontendUrl}/history/${childKey}`
 
                     csvRows.push([
-                        `"${childName.replace(/"/g, '""')}"`,
                         `"${this.recordKey}"`,
+                        `"${parentUrl}"`,
+                        `"${parentName}"`,
                         `"${reportingKey}"`,
+                        `"${childName.replace(/"/g, '""')}"`,
+                        `"${childKey}"`,
                         `"${childUrl}"`
                     ]);
                 }


### PR DESCRIPTION
In accordance to Rob's comment in Issue #457, the following changes were made to both the Provenance and Children CSVs.

Changes to the Provenance CSV:
- Device Key, Device URL and Reporting Key column were added.
- Children Keys and Children URL were removed.

Below is a screenshot of the updated provenance csv:
![Screenshot 2025-06-25 221927](https://github.com/user-attachments/assets/fe014010-e7ba-4ac5-87e2-6e1dedd843c9)
 
Changes to the Children CSV:
- The Parent Key, The Parent URL, The Parent Device Name, The Device Name, The child Key, The child URL were arranged respectively.
- The child URL was fixed.
- Added reporting key row back and instead added isReportingKey column that has a T flag when the row is the reporting key row and a F flag otherwise.

Below is a screenshot of the updated children key csv:
![Screenshot 2025-06-25 224257](https://github.com/user-attachments/assets/e930cd96-5686-4ddb-8d26-dc96bcbe7ae7)