### PR TITLE
Updated child key URL format in Group CSVs

### DIFF
--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -45,7 +45,7 @@ export default {
                     const record = provenanceList?.[0]?.record || {};
 
                     const childName = record.deviceName || '';
-                    const childUrl = `${useRuntimeConfig().public.frontendUrl}/history/${childKey}`;
+                    const childUrl = `${window.location.origin}/history/${childKey}`;
 
                     if (childKey == reportingKey){
                         isReportingKey = 'T';


### PR DESCRIPTION
Removed the use of the frontendUrl environment variable when creating child key URLs. Now uses the current window's URL as the starting point. Child key URLs should now match all parent key URLs i.e: gosqas, redstone, and the gdt-test endpoint.

<img width="1040" height="92" alt="image" src="https://github.com/user-attachments/assets/e84393ef-6301-4042-9150-2d27e4e91f0f" />
