### PR TITLE
Fixed "Download Children Keys as CSV" Bug

### DIFF
--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -39,7 +39,7 @@ export default {
 
                 const csvRows = [['Parent Record Key', 'Parent URL', 'Parent Device Name', 'Reporting Key', 'Child Name', 'Child Key', 'Child Key URL', 'isReportingKey']];
 
-                for (let i=0; i < provenance?.[0]?.record.children_key.length; i++) {
+                for (const childKey of filteredChildrenKeys) {
                 
                     const provenanceList = await getProvenance(childKey);
                     const record = provenanceList?.[0]?.record || {};


### PR DESCRIPTION
The definition for the variable "childKey" had been removed, I added it back and it fixed the issue. Below are screenshots of the download working for me.

The download going through after the button was clicked:
<img width="1197" height="725" alt="Screen Shot 2025-08-30 at 1 29 15 PM" src="https://github.com/user-attachments/assets/2eb19113-d9fd-42e2-ba7b-696f9a64eaba" />

The downloaded file:
<img width="1438" height="393" alt="Screen Shot 2025-08-30 at 1 29 38 PM" src="https://github.com/user-attachments/assets/e0cb9731-90d9-485e-b2ba-c8815095ae9f" />