### PR TITLE
Fixed Gap Between Video and Text

### DIFF
--- a/packages/frontend/pages/about.vue
+++ b/packages/frontend/pages/about.vue
@@ -42,13 +42,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <p> <span class="p-text-color" style="font-weight:600">Our current products</span> <br>
                 Global Distributed Tracking - an open source software enabling closed-loop tracking for products, information, and logistics.</p>
                 <iframe src="https://player.vimeo.com/video/1083699280?h=941a4ccf67&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
-                       style="width: 100%; height: 600px; border: none; display: block;"
-                       frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
+                    style="width: 100%; border: none; display: block; aspect-ratio: 7 / 4;"
+                    frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
                </iframe>
                <p id="video-caption" style="font-size: 14px;">Video production by <a href="https://www.prodigium-pictures.com/" style="font-size: 14px;">Prodigium Pictures</a></p>
         </div>
 
-        <div class="row" >
+        <div>
         <RouterLink to="/how-it-works"><button class="baseButton button first about-button" id="about-button" style="
                   border-width: 2px;
                   border-style: solid;
@@ -61,7 +61,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                     How It Works
                 </button></RouterLink>
         
-        <div class="dmdm" >
+        <div class="dmdm test" >
                   <img src="../assets/images/dmdm-lightmode.svg" style="width: 100%; margin-bottom:20px; margin-top:20px" class="dmdm-image lightmode-dmdm">
                  <img src="../assets/images/dmdm-darkmode.svg" style="width: 100%; margin-bottom:20px; margin-top:20px" class="dmdm-image darkmode-dmdm">
                 <div class="dmdm-description" style="max-width: 100%;">
@@ -184,6 +184,7 @@ export default {
 .dmdm {
     display: flex;
     align-items: center; 
+    margin-top: 25px;
   }
 
 .lightmode-dmdm,
@@ -208,9 +209,13 @@ export default {
         color: #FFFFFF;
     }
     #about-button {
-        color: white;
+        color: #CCECFD;
         background-color: #1E2019;
         border: 2px solid #CCECFD;
+    }
+    #about-button:hover {
+        background-color: #CCECFD;
+        color: black;
     }
     .dmdm-header {
         margin-bottom:12px;
@@ -249,7 +254,11 @@ export default {
     #about-button {
         color: #322253;
         background-color: #FFFFFF;
-        border: 2px solid #322253;
+        border: 2px solid #4E3681;
+    }
+    #about-button:hover {
+        background-color: #4E3681;
+        color: white;
     }
     .dmdm-header {
         margin-bottom:15px;

--- a/packages/frontend/pages/dmdm.vue
+++ b/packages/frontend/pages/dmdm.vue
@@ -60,8 +60,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         </div>
 
     <iframe src="https://player.vimeo.com/video/1086646484?h=f0cbc7fd6d&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
-                        style="width: 100%;  height: 600px; border: none; display: block;"
-    frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="How to Create a Group Record with Decentralized Medical Device Manufacturing (DMDM)"></iframe>
+        style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+        frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="How to Create a Group Record with Decentralized Medical Device Manufacturing (DMDM)"></iframe>
     <p id="video-caption" style="font-size: 14px;">Video production by <a href="https://www.prodigium-pictures.com/" style="font-size: 14px;">Prodigium Pictures</a></p>
 
     </div>

--- a/packages/frontend/pages/donate.vue
+++ b/packages/frontend/pages/donate.vue
@@ -33,8 +33,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         </div>
 
         <iframe src="https://player.vimeo.com/video/1083699280?h=941a4ccf67&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
-                       style="width: 100%; height: 600px; display: block"
-                       frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
+            style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+            frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
          </iframe>
          <p id="video-caption" style="font-size: 14px;">Video production by <a href="https://www.prodigium-pictures.com/" style="font-size: 14px;">Prodigium Pictures</a></p>
 

--- a/packages/frontend/pages/how-it-works.vue
+++ b/packages/frontend/pages/how-it-works.vue
@@ -93,19 +93,22 @@ const route = useRoute()
                 <iframe
                     src="https://player.vimeo.com/video/1083699274?h=ff0b41174c&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
                     class="my-2"
-                    style="width: 100%; height: 699px; border: none; display: block; "frameborder="0"
+                    style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+                    frameborder="0"
                     allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media"
                     title="Tutorial: Creating A Record"></iframe>
                 <div class="divider"> </div>
                 <iframe
                     src="https://player.vimeo.com/video/1083699286?h=e63a8e8c21&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
                     class="my-2"
-                    style="width: 100%; height: 699px; border: none; display: block; "frameborder="0"
+                    style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+                    frameborder="0"
                     allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media"
                     title="Tutorial: Using A Record"></iframe>
                 <div class="divider"> </div>
                 <iframe src="https://player.vimeo.com/video/1086646484?h=f0cbc7fd6d&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
-                    style="width: 100%; height: 699px; border: none; display: block; "frameborder="0"
+                    style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+                    frameborder="0"
                     class="my-2"
                     allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media"
                     title="Tutorial: How to Create a Group Record with Decentralized Medical Device Manufacturing (DMDM)"></iframe>

--- a/packages/frontend/pages/index.vue
+++ b/packages/frontend/pages/index.vue
@@ -49,8 +49,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           <h3>Global Distributed Tracking</h3>
           <p style="font-weight: 400; padding-bottom: 15px">The Global Open Source Quality Assurance System proudly presents Global Distributed Tracking (GDT)&mdash;a free and open-source tracking platform. By reducing fraud, theft, counterfeiting, and lost shipments with secure encryption and a simple user interface, GDT helps create trust through transparency for your organization. </p>
                <iframe src="https://player.vimeo.com/video/1083699280?h=941a4ccf67&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
-                       style="width: 100%; height: 699px; border: none; display: block;"
-                       frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
+                    style="width: 100%; display: block; aspect-ratio: 7 / 4;"
+                    frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" title="Global Distributed Tracking">
                </iframe>
                <p id="video-caption" style="font-size: 14px;">Video production by <a href="https://www.prodigium-pictures.com/" style="font-size: 14px;">Prodigium Pictures</a></p>
         </div>


### PR DESCRIPTION
Found the issue with the gap between the video and the text. Basically, since the height was set to 600px the frame always had to have that height, even if the video couldn't fill it. By removing that property and replacing it with aspect-ratio instead, the frame now dynamically adjusts it's height while keeping width = 100%.

I fixed this for the Homepage, DMDM, How It Works, About Us, and Donation pages. These were the only ones that I saw with videos, but if I missed any please let me know!

Below are screenshots of the screen at different sizes:

Full laptop screen:
<img width="612" height="535" alt="full_screen" src="https://github.com/user-attachments/assets/1cff0b5b-df63-42a0-8946-88aeedfc9df7" />

Mobile View:
<img width="334" height="388" alt="mobile" src="https://github.com/user-attachments/assets/bae09e11-a6ec-4bfd-a97e-2bb8b1d0bfe5" />