### PR TITLE
Added keyFuncs service to backend

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "gosqas-az-func",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gosqas-az-func",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@azure/communication-email": "^1.0.0",
         "@azure/data-tables": "^13.3.1",
         "@azure/functions": "^4.0.1",
         "@azure/storage-blob": "^12.24.0",
+        "@urlpack/base58": "^2.0.1",
         "bs58": "^5.0.0",
         "dotenv": "^16.4.5",
         "json5": "^2.2.3"
@@ -1355,6 +1356,21 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/@urlpack/base-codec": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@urlpack/base-codec/-/base-codec-2.0.1.tgz",
+      "integrity": "sha512-unFqfDYmQFgowiFyW/be66HVIGeeo+7SMf6KWF16pQzQwDnf9NS3QkJsr727LGkH7f0jCImdd/mjr3iw/W7c/g==",
+      "license": "MIT"
+    },
+    "node_modules/@urlpack/base58": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@urlpack/base58/-/base58-2.0.1.tgz",
+      "integrity": "sha512-36e+qEGhdoxchUnQs+7APLtXsqXpQnfCW+cwlyi9hvpPzhNX2WkB8blvwnjAS4NItDNQRL/eafyw5qIrP35qsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@urlpack/base-codec": "^2.0.1"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.1.8",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
     "@azure/data-tables": "^13.3.1",
     "@azure/functions": "^4.0.1",
     "@azure/storage-blob": "^12.24.0",
+    "@urlpack/base58": "^2.0.1",
     "bs58": "^5.0.0",
     "dotenv": "^16.4.5",
     "json5": "^2.2.3"

--- a/packages/backend/src/services/keyFuncs.spec.ts
+++ b/packages/backend/src/services/keyFuncs.spec.ts
@@ -1,0 +1,45 @@
+// keyFuncs.spec.ts
+// Copyright (C) 2024 GOSQAS Team
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, it, expect } from 'vitest';
+import { validateKey, makeEncodedDeviceKey } from './keyFuncs';
+
+describe('validateDeviceKey', () => {
+    it('should return true when given a valid device key', () => {
+        expect(validateKey("SsxFac4pPz4Rs7jFwSt2mp")).toEqual(true);
+
+        const key = makeEncodedDeviceKey();
+        expect(validateKey(key)).toEqual(true);
+    });
+
+    it('should return false when given an invalid string', () => {
+      expect(validateKey("abc123")).toEqual(false); // Too short
+      expect(validateKey("SsxFac4pPz4Rs7jFwSt2mp1")).toEqual(false); // Too long
+      expect(validateKey("!@#$%^&*#z4R!7jFwSt2mp")).toEqual(false); // Invalid characters
+    });
+    
+    it('should return false when not given a string', () => {
+      // @ts-ignore
+      expect(validateKey(5)).toEqual(false);    
+      // @ts-ignore
+      expect(validateKey([])).toEqual(false);
+      // @ts-ignore
+      expect(validateKey(null)).toEqual(false);
+      // @ts-ignore
+      expect(validateKey(undefined)).toEqual(false);
+      // @ts-ignore
+      expect(validateKey({})).toEqual(false);
+    });
+});

--- a/packages/backend/src/services/keyFuncs.ts
+++ b/packages/backend/src/services/keyFuncs.ts
@@ -1,0 +1,45 @@
+// keyFuncs.ts -- Creation and Function of Key
+// Copyright (C) 2024 GOSQAS Team
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import {encode as base58encode } from '@urlpack/base58'
+import {randomBytes} from 'crypto';
+
+export function makeDeviceKey(): Uint8Array{
+  // Generates 16 bytes ( i.e., 128 bits) of random data.
+  // This is the same as AES-128 key length from the frontend
+  const key = randomBytes(16);
+  return new Uint8Array(key);
+}
+
+function encodeDeviceKey(key: Uint8Array): string {
+  return base58encode(key);
+}
+
+export function makeEncodedDeviceKey(): string {
+  let newEncodedKey = encodeDeviceKey(makeDeviceKey());
+  // Try a few times to make sure the key is valid (length == 22)
+  for (let count = 0; count < 10; count++) {
+    newEncodedKey = encodeDeviceKey(makeDeviceKey());
+    if (newEncodedKey.length == 22) {
+      break;
+    }
+  }
+  return newEncodedKey;
+}
+
+export function validateKey(key: string): boolean {
+  const alphanumericRegex = /^[a-zA-Z0-9]+$/;
+  return typeof key === 'string' && key.length === 22 && alphanumericRegex.test(key);
+}

--- a/packages/backend/test/services/keyFuncs.spec.ts
+++ b/packages/backend/test/services/keyFuncs.spec.ts
@@ -1,20 +1,5 @@
-// keyFuncs.spec.ts
-// Copyright (C) 2024 GOSQAS Team
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import { describe, it, expect } from 'vitest';
-import { validateKey, makeEncodedDeviceKey } from './keyFuncs';
+import { validateKey, makeEncodedDeviceKey } from '../../src/services/keyFuncs';
 
 describe('validateDeviceKey', () => {
     it('should return true when given a valid device key', () => {


### PR DESCRIPTION
- Copy keyFuncs.ts and keyFuncs.spec.ts from frontend to backend
- Adapt for Node.js crypto API instead of Web Crypto API
- Remove async/await since Node.js randomBytes is synchronous
- Maintain same functionality and validation logic
- Tests should run with existing Vitest setup