### PR TITLE
Added 2MB File Size Limit

### DIFF
--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -112,7 +112,7 @@ export default {
         onFileChange(e: Event) {
             const target = e.target as HTMLInputElement;
             const files = target.files;
-            // TODO: change file size as needed
+
             const maxFileSize = 2097152;  // aka 2MB
 
             if (files && files[0].size <= maxFileSize) {

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -111,7 +111,7 @@ export default {
         onFileChange(e: Event) {
             const target = e.target as HTMLInputElement;
             const files = target.files;
-            // TODO: change file size as needed
+
             const maxFileSize = 2097152;  // aka 2MB
 
             if (files && files[0].size <= maxFileSize) {

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -183,7 +183,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         onFileChange(e: Event) {
             const target = e.target as HTMLInputElement;
             const files = target.files;
-            // TODO: change file size as needed
+
             const maxFileSize = 2097152;
 
             if (files && files[0].size <= maxFileSize) {


### PR DESCRIPTION
I added a file limit on all pages where you can add files.

I wasn't sure what file size we wanted as our upper limit, the internet had varying answers but 2MB seemed to be a pretty consistent one (Personally I couldn't find image files that were even 1MB on my computer, but I don't know what images/files are being uploaded and don't want to accidentally block real images). The upper limit can be easily changed if we want/need to.

Below is a screenshot of what happens if the file is too large, it creates a pop up and then removes the file from the input area.
<img width="1193" height="560" alt="Screen Shot 2025-09-23 at 5 31 46 PM" src="https://github.com/user-attachments/assets/dabca9d8-48db-4549-b271-d1a3742e1103" />
