### PR TITLE
Record Creation Smoketests for the API

### DIFF
--- a/packages/backend/test/IntegrationTests/Live/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/create.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, vi, it, expect } from "vitest";
+import { makeEncodedDeviceKey, validateKey } from '../../../src/utils/keyFuncs';
+import { postProvenance, getNewDeviceKey } from '../../../src/functions/httpTrigger';
 
 /* README: To add a test, add inside the global describe an additional it. For example:
 
@@ -43,22 +45,111 @@ describe("Group Creation Tests", () => {
 	
 });
 
+// TODO: Add record creation tests here
+function makeHttpRequest(deviceKey: any, formData: any, overrides: any = {}) {
+	return {
+	  method: 'POST',
+	  url: '/',
+	  headers: new Headers(),
+	  query: {},
+	  params: { deviceKey: deviceKey },  // for makeEncodedDeviceKey
+	//   params: { deviceKey },  // for getNewDeviceKey
+	  user: undefined,
+	  body: undefined,
+	  bodyUsed: false,
+	  arrayBuffer: async () => new ArrayBuffer(0),
+	  text: async () => '',
+	  json: async () => ({}),
+	  formData: async () => (formData),
+	  ...overrides,
+	};
+  }
+
 describe("Record Creation Tests", () => {
+	// TODO: works on localhost (need to run azurite and set BACKEND_URL to localhost 7071), but still fails to GET on gdtprod
+	const baseUrl = 'http://localhost:7071/api/provenance/'  // localhost (works)
+	// const baseUrl = 'https://gdtprodbackend.azurewebsites.net/api/provenance/'  // url from read tests (fails)
+
+
+	// Create the most basic record
+	it("record creation test", async () => {
+		try {
+			// Create record key
+			const deviceKey = await makeEncodedDeviceKey();
+			console.log("Created Device Key: " + deviceKey);
+
+			const fullUrl = `${baseUrl}${deviceKey}`
+
+			expect(deviceKey.length).toBe(22);
+			expect(validateKey(deviceKey)).toBe(true);
+
+
+			// POST record to backend
+			const data = {
+				blobType: 'deviceInitializer',
+				deviceName: "Create Record Test",
+				description: "An API smoketest for the Create Record feature",
+				tags: {},
+				children_key: '',
+				hasParent: false,
+				isReportingKey: false,
+			}
+			const formData = new FormData();
+    		formData.append("provenanceRecord", JSON.stringify(data));
+
+			let req = makeHttpRequest(deviceKey, formData);
+
+			const context = {
+				invocationId: 'test-invocation-id',
+				functionName: 'test-function',
+				extraInputs: { get: vi.fn(), set: vi.fn() },
+				extraOutputs: { get: vi.fn(), set: vi.fn() },
+				log: vi.fn(), trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn(),
+				options: { trigger: { type: 'http', name: 'req' }, extraInputs: [], extraOutputs: [] },
+			};
+
+			const postResponse = await postProvenance(req, context);
+			console.log("postProv Response: " + JSON.stringify(postResponse));
+			
+			expect(postResponse).toHaveProperty('jsonBody');
+
+
+			// GET record to make sure it exists
+			let getResponse; 
+			try {
+				getResponse = await fetch(fullUrl);
+				getResponse = await getResponse.json();
+				console.log("getProv Response: " + JSON.stringify(getResponse) + " type: " + typeof(getResponse));
+			} catch(error) {
+				console.error('(Create GET Test) Failed to fetch url: ' + fullUrl + '\nError: ' + error) 
+				throw error;
+			}
+
+			expect(JSON.stringify(getResponse)).not.toBe('[]');
+			expect(typeof(getResponse)).toBe('object');
+
+		} catch (error) {
+			console.error("(Create POST Test) Error creating a record: " + error); 
+			throw error;
+		}
+	}, 100000);  // TODO: last value is timeout value (remove/shorten if it is not needed anymore)
+
+
 
 	// Placeholder
-	// The most basic possible test
+	// The most basic possible test (create a record) -- working on that now, see above
 	it("smoketest", () => {
 		expect(0).toBe(0);
 	});
 
 	// Placeholder
-	// Most basic + one feature
+	// Most basic + one feature -- create a record with tags
 	it("smoketest", () => {
 		expect(0).toBe(0);
 	});
 
 	// Placeholder
-	// Everything all at once
+	// Everything all at once -- create a record with tags and an image?
 	it("feature-complete test", () => {
 		expect(0).toBe(0);
 	});

--- a/packages/backend/test/IntegrationTests/Live/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/create.test.ts
@@ -100,22 +100,29 @@ describe("Record Creation Tests", () => {
 			const formData = new FormData();
     		formData.append("provenanceRecord", JSON.stringify(data));
 
-			let req = makeHttpRequest(deviceKey, formData, fullUrl);
+			// TODO: USE FETCH TO POST!!
+			const postResponse = await fetch(fullUrl, {
+				method: "POST",
+				body: formData,
+			});
+			console.log("response: ", postResponse);
 
-			const context = {
-				invocationId: 'test-invocation-id',
-				functionName: 'test-function',
-				extraInputs: { get: vi.fn(), set: vi.fn() },
-				extraOutputs: { get: vi.fn(), set: vi.fn() },
-				log: vi.fn(), trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn(),
-				options: { trigger: { type: 'http', name: 'req' }, extraInputs: [], extraOutputs: [] },
-			};
+			// let req = makeHttpRequest(deviceKey, formData, fullUrl);
 
-			// Call postProv
-			const postResponse = await postProvenance(req, context);
-			console.log("postProv Response: " + JSON.stringify(postResponse));
+			// const context = {
+			// 	invocationId: 'test-invocation-id',
+			// 	functionName: 'test-function',
+			// 	extraInputs: { get: vi.fn(), set: vi.fn() },
+			// 	extraOutputs: { get: vi.fn(), set: vi.fn() },
+			// 	log: vi.fn(), trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn(),
+			// 	options: { trigger: { type: 'http', name: 'req' }, extraInputs: [], extraOutputs: [] },
+			// };
+
+			// // Call postProv
+			// const postResponse = await postProvenance(req, context);
+			// console.log("postProv Response: " + JSON.stringify(postResponse));
 			
-			expect(postResponse).toHaveProperty('jsonBody');
+			// expect(postResponse).toHaveProperty('jsonBody');
 		} catch (error) {
 			console.error("(Create POST Test) Error creating a record: " + error); 
 			throw error;

--- a/packages/backend/test/IntegrationTests/Live/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/create.test.ts
@@ -111,6 +111,7 @@ describe("Record Creation Tests", () => {
 				options: { trigger: { type: 'http', name: 'req' }, extraInputs: [], extraOutputs: [] },
 			};
 
+			// Call postProv
 			const postResponse = await postProvenance(req, context);
 			console.log("postProv Response: " + JSON.stringify(postResponse));
 			
@@ -119,10 +120,6 @@ describe("Record Creation Tests", () => {
 			console.error("(Create POST Test) Error creating a record: " + error); 
 			throw error;
 		}
-
-		// TODO: remove this line
-		// baseUrl = 'http://localhost:7071/api/provenance/'
-		// fullUrl = `${baseUrl}${deviceKey}`
 
 		// GET the record to make sure it exists
 		let getResponse; 


### PR DESCRIPTION
Added three record creation tests:
- 1st creates the most basic record
- 2nd creates a record with tags
- 3rd creates a record with tags and an image attachment

Below are screenshots of all three tests succeeding after running 'npm run api_integration_tests' (all created records are posted to Bluestone/prod). You can go to the keys shown below to view them, or run the api integration tests to create 3 new records with the same features.

1st test:
<img width="1289" height="718" alt="Screen Shot 2025-10-04 at 12 42 55 PM" src="https://github.com/user-attachments/assets/91281f4a-6f32-4b20-bf06-c310d76986ec" />

2nd test:
<img width="1292" height="727" alt="Screen Shot 2025-10-04 at 12 43 20 PM" src="https://github.com/user-attachments/assets/699c8cd0-6242-40db-826a-668170b00db3" />

3rd test:
<img width="1289" height="766" alt="Screen Shot 2025-10-04 at 12 43 46 PM" src="https://github.com/user-attachments/assets/353f902d-f55d-45aa-ac9f-e1497ea625f9" />