### PR TITLE
added Group Record Creation smoketests

### DIFF
--- a/packages/backend/test/IntegrationTests/Live/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/create.test.ts
@@ -23,23 +23,207 @@ describe("Group of tests", () => {
 
 describe("Group Creation Tests", () => {
 
-	// Placeholder
 	// The most basic possible test
-	it("smoketest", () => {
-		expect(0).toBe(0);
-	});
+	it("should create a group record with one child", async () => {
+		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
+		
+		// Generate device keys
+		const groupKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+		const childKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+		
+		// Create child record
+		const childFormData = new FormData();
+		childFormData.append("provenanceRecord", JSON.stringify({
+			blobType: "deviceInitializer",
+			deviceName: "child_smoketest",
+			description: "child for most basic smoketest group record creation",
+			tags: [],
+			children_key: "",
+			hasParent: false,
+			isReportingKey: false
+		}));
+		
+		const childResponse = await fetch(`${baseUrl}/provenance/${childKey}`, {
+			method: "POST",
+			body: childFormData,
+		});
+		
+		expect(childResponse.ok).toBe(true);
+		
+		// Create group record
+		const groupFormData = new FormData();
+		groupFormData.append("provenanceRecord", JSON.stringify({
+			blobType: "deviceInitializer",
+			deviceName: "group_smoketest",
+			description: "group for most basic smoketest group record creation",
+			tags: [],
+			children_key: [childKey],
+			hasParent: false,
+			isReportingKey: false
+		}));
+		
+		const groupResponse = await fetch(`${baseUrl}/provenance/${groupKey}`, {
+			method: "POST",
+			body: groupFormData,
+		});
+		
+		expect(groupResponse.ok).toBe(true);
+	}, 30000);
 
-	// Placeholder
+
 	// Most basic + one feature
-	it("smoketest", () => {
-		expect(0).toBe(0);
-	});
+	it("should create a group record with multiple children", async () => {
+		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
+		
+		// Generate device keys
+		const groupKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+		const childKeys: string[] = [];
+		
+		// Generate multiple child keys using a loop
+		for (let i = 0; i < 3; i++) {
+			const childKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+			childKeys.push(childKey);
+		}
+		
+		// Create child records using a loop
+		for (let i = 0; i < childKeys.length; i++) {
+			const childFormData = new FormData();
+			childFormData.append("provenanceRecord", JSON.stringify({
+				blobType: "deviceInitializer",
+				deviceName: `child_${i + 1}_smoketest`,
+				description: `child ${i + 1} for multiple children smoketest`,
+				tags: [],
+				children_key: "",
+				hasParent: false,
+				isReportingKey: false
+			}));
+			
+			const childResponse = await fetch(`${baseUrl}/provenance/${childKeys[i]}`, {
+				method: "POST",
+				body: childFormData,
+			});
+			
+			expect(childResponse.ok).toBe(true);
+		}
+		
+		// Create group record with all children
+		const groupFormData = new FormData();
+		groupFormData.append("provenanceRecord", JSON.stringify({
+			blobType: "deviceInitializer",
+			deviceName: "group_multiple_children_smoketest",
+			description: "group with multiple children for smoketest",
+			tags: [],
+			children_key: childKeys,
+			hasParent: false,
+			isReportingKey: false
+		}));
+		
+		const groupResponse = await fetch(`${baseUrl}/provenance/${groupKey}`, {
+			method: "POST",
+			body: groupFormData,
+		});
+		
+		expect(groupResponse.ok).toBe(true);
 
-	// Placeholder
+		// Verify group record was created with multiple children
+		const retrievedGroupResponse = await fetch(`${baseUrl}/provenance/${groupKey}`);
+		const retrievedGroup = await retrievedGroupResponse.json();
+		expect(retrievedGroup[0].record.children_key).toEqual(childKeys);
+
+		// Verify all child records were created
+		for (let i = 0; i < childKeys.length; i++) {
+			const retrievedChildResponse = await fetch(`${baseUrl}/provenance/${childKeys[i]}`);
+			const retrievedChild = await retrievedChildResponse.json();
+			
+			expect(retrievedChild).toBeDefined();
+			expect(retrievedChild.length).toBeGreaterThan(0);
+			expect(retrievedChild[0].record.deviceName).toBe(`child_${i + 1}_smoketest`);
+		}
+	}, 30000);
+
+
 	// Everything all at once
-	it("feature-complete test", () => {
-		expect(0).toBe(0);
-	});
+	it("should create a group record with all features", async () => {
+		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
+		
+		// Generate device keys
+		const groupKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+		const childKeys: string[] = [];
+		
+		// Generate multiple child keys using a loop
+		for (let i = 0; i < 3; i++) {
+			const childKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text();
+			childKeys.push(childKey);
+		}
+		
+		// Create child records with tags and detailed descriptions
+		for (let i = 0; i < childKeys.length; i++) {
+			const childFormData = new FormData();
+			childFormData.append("provenanceRecord", JSON.stringify({
+				blobType: "deviceInitializer",
+				deviceName: `child_${i + 1}_feature_complete_creation`,
+				description: `Child ${i + 1} with full features`,
+				tags: ["feature-complete", "child", `child-${i + 1}`],
+				children_key: "",
+				hasParent: false,
+				isReportingKey: false
+			}));
+			
+			const childResponse = await fetch(`${baseUrl}/provenance/${childKeys[i]}`, {
+				method: "POST",
+				body: childFormData,
+			});
+			
+			expect(childResponse.ok).toBe(true);
+		}
+		
+		// Create group record with all features
+		const groupFormData = new FormData();
+		groupFormData.append("provenanceRecord", JSON.stringify({
+			blobType: "deviceInitializer",
+			deviceName: "group_all_features_creation",
+			description: "Comprehensive group record creation with all features for smoketest",
+			tags: ["feature-complete", "group", "comprehensive", "all-features"],
+			children_key: childKeys,
+			hasParent: false,
+			isReportingKey: false
+		}));
+		
+		const groupResponse = await fetch(`${baseUrl}/provenance/${groupKey}`, {
+			method: "POST",
+			body: groupFormData,
+		});
+		
+		expect(groupResponse.ok).toBe(true);
+		
+		// Verify group record was created with all features
+		const retrievedGroupResponse = await fetch(`${baseUrl}/provenance/${groupKey}`);
+		const retrievedGroup = await retrievedGroupResponse.json();
+		
+		expect(retrievedGroup).toBeDefined();
+		expect(retrievedGroup.length).toBeGreaterThan(0);
+		expect(retrievedGroup[0].record.blobType).toBe("deviceInitializer");
+		expect(retrievedGroup[0].record.deviceName).toBe("group_all_features_creation");
+		expect(retrievedGroup[0].record.children_key).toEqual(childKeys);
+		expect(retrievedGroup[0].record.tags).toContain("feature-complete");
+		expect(retrievedGroup[0].record.tags).toContain("group");
+		expect(retrievedGroup[0].record.tags.length).toBe(4);
+		expect(retrievedGroup[0].timestamp).toBeDefined();
+		expect(retrievedGroup[0].timestamp).toBeGreaterThan(0);
+		
+		// Verify all child records were created
+		for (let i = 0; i < childKeys.length; i++) {
+			const retrievedChildResponse = await fetch(`${baseUrl}/provenance/${childKeys[i]}`);
+			const retrievedChild = await retrievedChildResponse.json();
+			
+			expect(retrievedChild).toBeDefined();
+			expect(retrievedChild.length).toBeGreaterThan(0);
+			expect(retrievedChild[0].record.deviceName).toBe(`child_${i + 1}_feature_complete_creation`);
+			expect(retrievedChild[0].record.tags).toContain("feature-complete");
+			expect(retrievedChild[0].record.tags).toContain(`child-${i + 1}`);
+			expect(retrievedChild[0].record.tags.length).toBe(3);
+		}
+	}, 30000);
 	
 });
 


### PR DESCRIPTION
1. Followed the direction for record creation ([found here)](https://docs.google.com/document/d/1SUgA1zqSLmlBzpb6qjeX1VA5xYsjLOJa-qc3pWMpUGo/edit?tab=t.4807hbg9swkw) to create both parent and child record.
2. converted the curl to fetch with a converter and got this:
<img width="945" height="552" alt="smoketest_screenshoot1" src="https://github.com/user-attachments/assets/3e95dbef-73d0-43da-a252-d1180cfb759e" />

3. Created basic smoketest with only parent and one child.
4. Created smoketest with parent and multiple children.
5. Created smoketest with all possible features to test.
6. `cd backend && npm test -- test/IntegrationTests/Live/create.test.ts`, i.e. the group record creation smoketests by themselves gave the following:
<img width="853" height="486" alt="smoketest_screenshoot2" src="https://github.com/user-attachments/assets/3ea7ee0b-68a9-4a26-9673-f24edc52d684" />
