### PR TITLE
Mashed bullet-text fix: How-it-works page

### DIFF
--- a/packages/frontend/pages/how-it-works.vue
+++ b/packages/frontend/pages/how-it-works.vue
@@ -135,7 +135,7 @@ import Learn_more from '~/layouts/learn_more.vue';
 
 li {
     font-weight: 400;
-    text-indent: -20px;
+    text-indent: 10px;
     margin-left: 20px;
 }
 


### PR DESCRIPTION
Changed the 'text-indent' value of the list (li) style element from -20px to 10px. Bullet points no longer mashed.