### PR TITLE
Added Loading Screen to Asset History Page

### DIFF
--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -209,14 +209,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         },
         async submitRecord() {
             // Emit an event to notify the history/[deviceKey].vue page to display loading screen
-            EventBus.emit('isLoading');
+            EventBus.emit('isCreating');
 
             // Get a refreshed copy of the records
             let records;
             try {
                 records = await getProvenance(this.recordKey);
             } catch (e) {
-                EventBus.emit('isLoading');
+                EventBus.emit('isCreating');
             }
 
             if (!records || records.length === 0) {

--- a/packages/frontend/utils/event-bus.ts
+++ b/packages/frontend/utils/event-bus.ts
@@ -19,6 +19,7 @@ import type { Emitter } from 'mitt';
 interface Events {
   feedRefresh: void;
   isLoading: void;
+  isCreating: void;
   // Add other events here
 }
 


### PR DESCRIPTION
Added a few changes to make it clearer that a record is being created:
- Added a "creating record(s)" page when a record is being created and a "loading" page when the page is refreshed
- Added a success pop-up for when a record is successfully created
- Fixed error where loading screen would flash at the end of creating a record
- Made the page go back to the history page (with an error pop-up) when a record fails to create, rather than staying on the create page

Below are screenshots of what the page looks like when a record succeeds and fails to create (the creating page looks the same as the one from the previous issue):
<img width="1266" height="769" alt="Screenshot 2025-11-04 at 11 45 23 PM" src="https://github.com/user-attachments/assets/a2840116-740a-432f-9319-78eb33e73db1" />
<img width="1258" height="768" alt="Screenshot 2025-11-04 at 11 45 38 PM" src="https://github.com/user-attachments/assets/4f81a18d-7a07-43cb-8fc5-2332b184adad" />

A quick note: on PR #516 Jara mentioned an issue where the screen stays on the loading screen, even after record creation has already failed (From create device/group). At the time I didn't fully understand the implications of that, but after working on this I see how it could be confusing to see the loading screen when nothing is loading, especially if you miss the pop-up. I think it would be worth creating another issue to address this, as well as figuring out what we want that page to do instead (go back to the create device/group page? go to a new error page?). @paulErdos Let me know what you think and if I should create an issue for that.