### PR TITLE
Added Group Creation Feature Test - Tags

### DIFF
--- a/packages/backend/test/IntegrationTests/Live/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/create.test.ts
@@ -321,12 +321,7 @@ describe("Group Creation Tests", () => {
 		expect(retrievedChild[0].record.tags).toContain("tag-feature");
 		expect(retrievedChild[0].record.tags.length).toBe(2);
 	}, 60000);
-<<<<<<< HEAD
-
 	
-=======
-  
->>>>>>> a102ab3a08004524270b3052cdf29e4b25544034
 	// Group Creation test with 2 child keys + annotation
 	it("Group Creation - Annotating Child Records", async () => {
 


### PR DESCRIPTION
Added one test for group record creation with tags (parent: 2 tags, child: 2 tags). 
The test verifies that:
- The parent record has the tags
- The child record has the tags (For the purposes of this test, the group consists of one child.)

Please let me know if more test cases are required for this feature. Thank you @paulErdos 