### PR TITLE
Recall Feature Tests

### DIFF
--- a/packages/backend/test/IntegrationTests/Live/update.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/update.test.ts
@@ -286,7 +286,7 @@ describe("Record Update Tests", () => {
       body: updateFormData,
     });
 
-    // Call recall function to send recalled record to all the children and grandchildren
+    // Call the recall function to send recalled record to all the children and grandchildren
     const recallResponse = await fetch(`${baseUrl}recall/${groupKey}`, {
       method: "POST",
       body: updateFormData,


### PR DESCRIPTION
Implemented both 'recallChildren' and 'annotateChildren' functions in the backend, and created tests for the recall feature. Recall currently does work as intended/described, sending records to even children of children (the group key is printed when running api_integration_tests, so you can check the key to confirm that the recalled record was sent).

@paulErdos I haven't created feature tests for annotate as that wasn't a specific part of this issue, but I could create another issue for that if desired.

<img width="1264" height="741" alt="Screenshot 2025-12-14 at 1 29 57 PM" src="https://github.com/user-attachments/assets/032daf30-3e7b-4e6b-b6e0-aa39b91fbcc2" />
