### PR TITLE
Caching Requests

### DIFF
--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -143,7 +143,7 @@ async function fetchUrl(url: string, formData?: FormData) {
     }
 }
 
-export async function offlineTestFetch(url?: string): Promise<boolean> {
+export async function onlineTestFetch(url?: string): Promise<boolean> {
     let result = true;
 
     // This is added to make testing easier, if no parameter given -> defaults to pinging Google.
@@ -168,7 +168,7 @@ export async function offlineTestFetch(url?: string): Promise<boolean> {
 
 export async function connectivityChecker() {
     // While offlineTestFetch returns false, test for onlineness every 5 seconds. Return when back online (offlineTestFetch returns true)
-    while (!(await offlineTestFetch())) {
+    while (!(await onlineTestFetch())) {
         await new Promise((r) => setTimeout(r, 5000));
     }
 

--- a/packages/frontend/test/unitTests/azureFuncs.spec.ts
+++ b/packages/frontend/test/unitTests/azureFuncs.spec.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { offlineTestFetch } from '~/services/azureFuncs'
+import { onlineTestFetch } from '~/services/azureFuncs'
 import { cacheRequest } from '~/services/azureFuncs';
 import * as z from 'zod';
 
 describe('Tests to see if user is online and offline', () => {
     it('Test to see if user is online', async () => {
-        let result = await offlineTestFetch();
+        let result = await onlineTestFetch();
         expect(result).toBe(true);
     });
 
     it('Test to see if user is offline', async () => {
-        let result = await offlineTestFetch('https://www.fakeurl.com');
+        let result = await onlineTestFetch('https://www.fakeurl.com');
         expect(result).toBe(false);
     });
 


### PR DESCRIPTION
Made a function for offline mode that will take formUrl and formData and store them in localStorage under a unique string ("gosqas_offline_cache_#", with # being the current request number). Also wrote two tests for this function. The first one checks that requests are stored correctly and can be retrieved, the second one tests that multiple requests can be stored without overriding each other.

This function only stores the record, not attachments (there's a separate issue for that).

For the formatting fixes, when merging Hieu's branch in my changes caused some style inconsistency, I reverted that here. Mostly just went from 2 space to 4 space indentation (to better match the rest of the code/what it was before) and reverted '' back to "".