### PR TITLE
Fixed long name/description going off screen

### DIFF
--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -52,7 +52,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div v-for="(report, index) in filteredProvenanceDeviceInit" class="device-creation-box">
 
             <template v-if="report.record.blobType === 'deviceInitializer'">
-                <h3 id="createdDevicePoint">Created Record: {{ report.record.deviceName }}</h3>
+                <h3 id="createdDevicePoint" style="word-break: break-word;">Created Record: {{ report.record.deviceName }}</h3>
             </template>
 
             <div v-if="recalledRecord">
@@ -66,7 +66,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
             <div class="text"
                 style="font-family: 'Poppins', sans-serif; font-weight: 400; font-size: 20px; line-height: 30px;">
-                <span v-html="clickableLink(report.record?.description)"></span>
+                <span v-html="clickableLink(report.record?.description)" style="word-break: break-word;"></span>
             </div>
 
             <div class="mb-1 tag-container">

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -101,7 +101,7 @@ const recordHasParent = hasParent(provenance);
 			<div class="record-description">
 				<div class="my-4 text-iris fs-1">
 				<p class="text-bold mb-0 device-name">Asset History Records</p>
-				<h1 class="mt-1 mb-1">
+				<h1 class="mt-1 mb-1" style="word-break: break-word;">
 					{{ deviceRecord?.deviceName }}
 				</h1>
 				</div>
@@ -113,7 +113,7 @@ const recordHasParent = hasParent(provenance);
 				<div class="rec" v-else>Record Key: {{ _recordKey }}</div>
 
 				<div class="mb-3 rec">
-				<span style="word-wrap: break-word;" v-html="clickableLink(deviceRecord?.description)"></span>
+				<span v-html="clickableLink(deviceRecord?.description)" style="word-break: break-word;"></span>
 				</div>
 
 				<section ref="section" id="priority-notices">

--- a/packages/frontend/pages/record/[deviceKey].vue
+++ b/packages/frontend/pages/record/[deviceKey].vue
@@ -36,7 +36,7 @@ const recordHasParent = hasParent(provenance);
                         <div class="record-description">
                             <div class="my-4 fs-1">
                                 <p class="h text-bold mb-0">Asset History Records</p>
-                                <h1 class="mt-1 mb-1">
+                                <h1 class="mt-1 mb-1" style="word-break: break-word;">
                                     {{ deviceRecord?.deviceName }}
                                 </h1>
                             </div>
@@ -48,7 +48,7 @@ const recordHasParent = hasParent(provenance);
                             <div class="h5" v-else>Record Key: {{ _recordKey }}</div>
 
                             <div class="mb-3">
-                                <span style="word-wrap: break-word;" id="desc" v-html="clickableLink(deviceRecord?.description)"></span>
+                                <span id="desc" v-html="clickableLink(deviceRecord?.description)" style="word-break: break-word;"></span>
                             </div>
                         </div>
 
@@ -223,7 +223,6 @@ export default {
 
 .record-description {
     margin-right: 15px;
-    max-width: 60%;
 }
 
 .qr-code-wrapper {


### PR DESCRIPTION
When we had a really long device name or description the formatting of the record and history pages would break. I changed those's pages formatting so that really long words could wrap instead of going off screen. The name/description wraps on both mobile and desktop.

Below are some screenshots of the formatting now working, you can look at the issue to see how the formatting was before.

<img width="1207" height="720" alt="Screenshot 2026-03-16 at 9 10 42 PM" src="https://github.com/user-attachments/assets/98ba845f-de4e-4ce4-b632-a878a113515b" />
<img width="1206" height="685" alt="Screenshot 2026-03-16 at 9 10 59 PM" src="https://github.com/user-attachments/assets/0eccf745-15b2-4b9a-9331-1b5fc55268aa" />
<img width="572" height="697" alt="Screenshot 2026-03-16 at 9 13 19 PM" src="https://github.com/user-attachments/assets/f6750a2d-f00c-49e6-8e4d-48ad1733f08b" />
<img width="662" height="694" alt="Screenshot 2026-03-16 at 9 14 14 PM" src="https://github.com/user-attachments/assets/91c207cb-62c3-4311-a416-12c9b3add45c" />