### PR TITLE
Added feature: Custom Record Titles

### DIFF
--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -959,23 +959,35 @@ async function createChild(context: InvocationContext, custom_title: string = ""
     }
 }
 
-async function createChildren(context, number_of_children, custom_child_titles?: string[], tags?) {
+async function createChildren(context, number_of_children, custom_child_titles, tags?) {
     const childrenKeys = []  // Named to correspond with metadatum name expected by frontend
     let thisChild;
     let custom_title;
-    // custom_child_titles.reverse()
+    let j = 1;
+    let parent_name;
+
+    if (typeof custom_child_titles === 'string' || custom_child_titles instanceof String) {
+        parent_name = custom_child_titles;
+    } else {
+        // custom_child_titles.reverse();
+        // parent_name = custom_child_titles;
+    }
+    
     for (let i = 0; i <= 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
-        if (custom_child_titles?.length > 0) {
-            custom_title = custom_child_titles.at(-1)
+        if (parent_name) {
+            custom_title = `${parent_name} #${j}`;
+        } else if (j <= custom_child_titles.length) {
+            custom_title = custom_child_titles.at(j-1);
         } else {
-            custom_title = ""
+            custom_title = "";
         }
 
         if(!(thisChild = await createChild(context, custom_title, tags))) {
             continue;
         }
 
-        custom_child_titles?.pop()
+        j++;
+        // custom_child_titles?.pop()
         childrenKeys.push(thisChild)
         if(childrenKeys.length == number_of_children) { 
             break;
@@ -990,6 +1002,9 @@ async function createGroup(context, name, description, n_children, custom_child_
     const frontendUrl = process.env['frontend_url'];
     const apiUrl = process.env['api_url'];
 
+    if (!Array.isArray(custom_child_titles)) {
+        custom_child_titles = name;
+    }
     // Create children first
     let childKeys = await createChildren(context, n_children, custom_child_titles)
 
@@ -1023,7 +1038,7 @@ const GroupCreationOrderSchema = z.object({
     description: z.string(),
     tags: z.array(z.string()).optional(),
     number_of_children: z.number().optional(),
-    custom_record_titles: z.array(z.string()).optional(),
+    children_name: z.array(z.string()).optional(),
     create_reporting_key: z.boolean().optional(),
     annotate: z.boolean().optional(),
 });

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -968,9 +968,6 @@ async function createChildren(context, number_of_children, custom_child_titles, 
 
     if (typeof custom_child_titles === 'string' || custom_child_titles instanceof String) {
         parent_name = custom_child_titles;
-    } else {
-        // custom_child_titles.reverse();
-        // parent_name = custom_child_titles;
     }
     
     for (let i = 0; i <= 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
@@ -987,7 +984,6 @@ async function createChildren(context, number_of_children, custom_child_titles, 
         }
 
         j++;
-        // custom_child_titles?.pop()
         childrenKeys.push(thisChild)
         if(childrenKeys.length == number_of_children) { 
             break;

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -961,8 +961,8 @@ async function createChild(context: InvocationContext, custom_title: string = ""
     */ 
 
     try {
-        //const baseUrl = "https://gosqasbe.azurewebsites.net/api";
-        const baseUrl = 'http://localhost:7071/api'
+        const baseUrl = "https://gosqasbe.azurewebsites.net/api";
+        // const baseUrl = 'http://localhost:7071/api'
         const childKey = await (await fetch(`${baseUrl}/getNewDeviceKey`)).text(); // TODO: call function directly 
         
         // Create child and group records

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -1004,7 +1004,7 @@ async function createChildren(context, number_of_children, custom_child_titles, 
         parent_name = custom_child_titles;
     }
     
-    for (let i = 0; i <= 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
+    for (let i = 0; i < 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
         if (parent_name) {  // determines if parent deviceName, custom titles, or a blank title to be used for child deviceName
             custom_title = `${parent_name} #${j}`;
         } else if (j <= custom_child_titles.length) {
@@ -1018,6 +1018,7 @@ async function createChildren(context, number_of_children, custom_child_titles, 
         }
 
         j++;
+        context.log("http, thisChild: ", thisChild)
         childrenKeys.push(thisChild)
         if(childrenKeys.length == number_of_children) { 
             break;
@@ -1027,7 +1028,7 @@ async function createChildren(context, number_of_children, custom_child_titles, 
     return childrenKeys; 
 }
 
-async function createGroup(context, name, description, n_children, custom_child_titles) {
+async function createGroup(context, name, description, n_children: number = 0, custom_child_titles) {
     const baseUrl = process.env['backend_url'];
     const frontendUrl = process.env['frontend_url'];
     const apiUrl = process.env['api_url'];

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -971,7 +971,7 @@ async function createChildren(context, number_of_children, custom_child_titles, 
     }
     
     for (let i = 0; i <= 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
-        if (parent_name) {
+        if (parent_name) {  // determines if parent deviceName, custom titles, or a blank title to be used for child deviceName
             custom_title = `${parent_name} #${j}`;
         } else if (j <= custom_child_titles.length) {
             custom_title = custom_child_titles.at(j-1);
@@ -998,6 +998,8 @@ async function createGroup(context, name, description, n_children, custom_child_
     const frontendUrl = process.env['frontend_url'];
     const apiUrl = process.env['api_url'];
 
+    // checks if custom_child_titles is an array. If not, parent deviceName is passed as custom_child_titles
+    // this is to facilitate groups with missing children_name keys to use parent deviceName and an incrementing number as child titles
     if (!Array.isArray(custom_child_titles)) {
         custom_child_titles = name;
     }

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -951,7 +951,7 @@ async function emailSignupTestEndpoint(request: HttpRequest, context: Invocation
 }
 
 
-async function createChild(context: InvocationContext, custom_title: string = "", tags: string[] = []) {
+async function createChild(context: InvocationContext, custom_title: string, tags: string[] = []) {
     /* 
     Note to self: Curious that since children are created before the group parent (implied by groups taking the 
     list of child keys), hasParent is set before the parent exists. What if parent creation fails? Retries don't
@@ -992,28 +992,13 @@ async function createChild(context: InvocationContext, custom_title: string = ""
     }
 }
 
-async function createChildren(context, number_of_children, custom_child_titles, tags?) {
+async function createChildren(context, number_of_children: number, custom_child_titles: string[], tags?) {
     const childrenKeys = []  // Named to correspond with metadatum name expected by frontend
     let thisChild;
-    let custom_title;
-    let j = 1;
-    let parent_name;
-
-    // let child_titles_list = []
-    if (typeof custom_child_titles === 'string' || custom_child_titles instanceof String) {
-        parent_name = custom_child_titles;
-    }
+    let j = 0;
     
     for (let i = 0; i < 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
-        if (parent_name) {  // determines if parent deviceName, custom titles, or a blank title to be used for child deviceName
-            custom_title = `${parent_name} #${j}`;
-        } else if (j <= custom_child_titles.length) {
-            custom_title = custom_child_titles.at(j-1);
-        } else {
-            custom_title = "";
-        }
-
-        if(!(thisChild = await createChild(context, custom_title, tags))) {
+        if(!(thisChild = await createChild(context, custom_child_titles[j], tags))) {
             continue;
         }
 
@@ -1027,16 +1012,25 @@ async function createChildren(context, number_of_children, custom_child_titles, 
     return childrenKeys; 
 }
 
-async function createGroup(context, name, description, n_children: number = 0, custom_child_titles) {
+async function createGroup(context, name, description, n_children: number = 0, custom_child_titles: string[]) {
     const baseUrl = process.env['backend_url'];
     const frontendUrl = process.env['frontend_url'];
     const apiUrl = process.env['api_url'];
 
-    // checks if custom_child_titles is an array. If not, parent deviceName is passed as custom_child_titles
-    // this is to facilitate groups with missing children_name keys to use parent deviceName and an incrementing number as child titles
+    // determines if parent deviceName + record number, custom titles, or a blank title to be used for child deviceName
     if (!Array.isArray(custom_child_titles)) {
-        custom_child_titles = name;
-    }
+        custom_child_titles = []
+        for (let i = 0; i < n_children; i++) {
+                custom_child_titles.push(`${name} #${i + 1}`)
+        }
+    };
+
+    let customLen = custom_child_titles.length
+    if (n_children > customLen) {
+        for (let i = 0; i < n_children - customLen; i++) {
+            custom_child_titles.push("")
+        }
+    };
     // Create children first
     let childKeys = await createChildren(context, n_children, custom_child_titles)
 
@@ -1047,7 +1041,9 @@ async function createGroup(context, name, description, n_children: number = 0, c
         blobType: "deviceInitializer",
         deviceName: name,
         description: description,
+        number_of_children: n_children,
         children_key: childKeys,  // Note: this is what turns a record into a group
+        children_name: custom_child_titles,
         tags: [],            
         hasParent: false,
         isReportingKey: false

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -999,6 +999,7 @@ async function createChildren(context, number_of_children, custom_child_titles, 
     let j = 1;
     let parent_name;
 
+    // let child_titles_list = []
     if (typeof custom_child_titles === 'string' || custom_child_titles instanceof String) {
         parent_name = custom_child_titles;
     }

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -1018,7 +1018,6 @@ async function createChildren(context, number_of_children, custom_child_titles, 
         }
 
         j++;
-        context.log("http, thisChild: ", thisChild)
         childrenKeys.push(thisChild)
         if(childrenKeys.length == number_of_children) { 
             break;

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -1035,7 +1035,7 @@ export async function createGroupHandler(request: HttpRequest, context: Invocati
         let title = theRequest['deviceName']
         let description = theRequest['description']
         let n_children = theRequest['number_of_children']
-        let custom_child_titles = theRequest['custom_record_titles']
+        let custom_child_titles = theRequest['children_name']
         let theGroupRecordPageUrl = await createGroup(context, title, description, n_children, custom_child_titles)
         context.log(theGroupRecordPageUrl)
 

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -918,7 +918,7 @@ async function emailSignupTestEndpoint(request: HttpRequest, context: Invocation
 }
 
 
-async function createChild(context: InvocationContext, tags: string[] = []) {
+async function createChild(context: InvocationContext, custom_title: string = "", tags: string[] = []) {
     /* 
     Note to self: Curious that since children are created before the group parent (implied by groups taking the 
     list of child keys), hasParent is set before the parent exists. What if parent creation fails? Retries don't
@@ -936,7 +936,7 @@ async function createChild(context: InvocationContext, tags: string[] = []) {
         const childFormData = new FormData();
         childFormData.append("provenanceRecord", JSON.stringify({
             blobType: "deviceInitializer",
-            deviceName: "",
+            deviceName: custom_title,
             description: "",
             tags: tags,
             hasParent: true,
@@ -959,14 +959,23 @@ async function createChild(context: InvocationContext, tags: string[] = []) {
     }
 }
 
-async function createChildren(context, number_of_children, tags?) {
+async function createChildren(context, number_of_children, custom_child_titles?: string[], tags?) {
     const childrenKeys = []  // Named to correspond with metadatum name expected by frontend
     let thisChild;
+    let custom_title;
+    // custom_child_titles.reverse()
     for (let i = 0; i <= 3 * number_of_children; i++) {  // Re: 3 * num: three retries per; attempts are identical
-        if(!(thisChild = await createChild(context, tags))) {
+        if (custom_child_titles?.length > 0) {
+            custom_title = custom_child_titles.at(-1)
+        } else {
+            custom_title = ""
+        }
+
+        if(!(thisChild = await createChild(context, custom_title, tags))) {
             continue;
         }
 
+        custom_child_titles?.pop()
         childrenKeys.push(thisChild)
         if(childrenKeys.length == number_of_children) { 
             break;
@@ -976,13 +985,13 @@ async function createChildren(context, number_of_children, tags?) {
     return childrenKeys; 
 }
 
-async function createGroup(context, name, description, n_children) {
+async function createGroup(context, name, description, n_children, custom_child_titles) {
     const baseUrl = process.env['backend_url'];
     const frontendUrl = process.env['frontend_url'];
     const apiUrl = process.env['api_url'];
 
     // Create children first
-    let childKeys = await createChildren(context, n_children)
+    let childKeys = await createChildren(context, n_children, custom_child_titles)
 
     const groupKey = await makeEncodedDeviceKey()
     const groupFormData = new FormData();
@@ -1023,10 +1032,11 @@ export async function createGroupHandler(request: HttpRequest, context: Invocati
     try{
         let theRequest = await request.json()
         GroupCreationOrderSchema.parse(theRequest)
-        let title = theRequest['title']
+        let title = theRequest['deviceName']
         let description = theRequest['description']
         let n_children = theRequest['number_of_children']
-        let theGroupRecordPageUrl = await createGroup(context, title, description, n_children)
+        let custom_child_titles = theRequest['custom_record_titles']
+        let theGroupRecordPageUrl = await createGroup(context, title, description, n_children, custom_child_titles)
         context.log(theGroupRecordPageUrl)
 
         return {

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -24,7 +24,7 @@ describe("Group of tests", () => {
 describe("Group Creation v2 tests", () => {
     // Tests group child custom titles
 	it("Custom Record Titles", async () => {
-		const baseUrl = "http://localhost:7071/api";
+		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
         const groupParentRecords = []
         const groupedChildKeys = []
         const groupedChildTitles = []

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+/* README: To add a test, add inside the global describe an additional it. For example:
+
+describe("Group of tests", () => {
+	it("Brief description that this tests foo", () => {
+		var val = do_thing();
+		expect(val).toBe(0);
+	});
+
+	it("Brief description that this tests bar", () => {
+		// structured similar to above
+	});
+
+	it("Another test", () => {
+		// More test contents
+	});
+
+	// More tests
+})
+
+*/
+
+describe("Group Creation v2 tests", () => {
+	// it("Brief description that this tests foo", () => {
+	// 	var val = do_thing();
+	// 	expect(val).toBe(0);
+	// });
+
+	// it("Brief description that this tests bar", () => {
+	// 	// structured similar to above
+	// });
+
+	it("Custom Record Titles", async () => {
+		const baseUrl = "http://localhost:7071/api";
+        const customTitles = ["a1", "b2", "c3"];
+
+        const response = await fetch(`${baseUrl}/createGroup`, {
+            method: "POST",
+            body: JSON.stringify({
+                deviceName: "Group Title",
+                description: "Group Description",
+                number_of_children: 5,
+                children_name: customTitles
+            }) 
+        });
+
+        console.log("test:", await response.json())
+	});
+
+	// More tests
+})

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -35,84 +35,68 @@ describe("Group Creation v2 tests", () => {
         // number_of_children,
         // children_name ]
         const testCases = [
-            [
-                "0th Test",
-                "1 custom record title",
-                1,
-                ["a1"]
-            ],
-            [
-                "1st Test",
-                "3 custom record titles",
-                3,
-                ["a1", "b2", "c3"]
-            ],
-            [
-                "2nd Test",
-                "3 children, 1 custom record title, 2 records without custom title",
-                3,
-                ["a1"]
-            ],
-            [
-                "3rd Test",
-                "3 children, empty children_name array",
-                3,
-                []
-            ],
-            [
-                "4th Test",
-                "4 children, no children_name array",
-                4
-            ],
-            [
-                "",
-                "5th Test: completely empty parent deviceName string, no children_name array",
-                5
-            ],
-            [
-                " ",
-                "6th Test: single space as parent deviceName string, no children_name array",
-                6
-            ],
-            [
-                "7th Test",
-                "non-array children_name value, will fail Zod validation",
-                3,
-                "a"
-            ],
-            [
-                "8th Test",
-                "children_name array with unexpected number, will fail Zod validation",
-                3,
-                ["a1", 9, "c3"]
-            ]
+            {
+                deviceName: "0th Test",
+                description: "1 custom record title",
+                number_of_children: 1,
+                children_name: ["a1"]
+            },
+            {
+                deviceName: "1st Test",
+                description: "3 custom record titles",
+                number_of_children: 3,
+                children_name: ["a1", "b2", "c3"]
+            },
+            {
+                deviceName: "2nd Test",
+                description: "3 children, 1 custom record title, 2 records without custom title",
+                number_of_children: 3,
+                children_name: ["a1"]
+            },
+            {
+                deviceName: "3rd Test",
+                description: "3 children, empty children_name array",
+                number_of_children: 3,
+                children_name: []
+            },
+            {
+                deviceName: "4th Test",
+                description: "4 children, no children_name array",
+                number_of_children: 4
+            },
+            {
+                deviceName: "",
+                description: "5th Test: completely empty parent deviceName string, no children_name array",
+                number_of_children: 5
+            },
+            {
+                deviceName: " ",
+                description: "6th Test: single space as parent deviceName string, no children_name array",
+                number_of_children: 6
+            },
+            {
+                deviceName: "7th Test",
+                description: "non-array children_name value, will fail Zod validation",
+                number_of_children: 3,
+                children_name: "a"
+            },
+            {
+                deviceName: "8th Test",
+                description: "children_name array with unexpected number, will fail Zod validation",
+                number_of_children: 3,
+                children_name: ["a1", 9, "c3"]
+            }
         ]
         
         for (let i = 0; i < testCases.length; i++) {
             let currCase = testCases[i];
             let response;
 
-            // Creates group records based on whether or not test case contains children_name field
-            if (currCase.length === 4) {
-                response = await fetch(`${baseUrl}/createGroup`, {
-                    method: "POST",
-                    body: JSON.stringify({
-                        deviceName: currCase[0],
-                        description: currCase[1],
-                        number_of_children: currCase[2],
-                        children_name: currCase[3]
-                    })
-                });
-            } else {
-                response = await fetch(`${baseUrl}/createGroup`, {
-                    method: "POST",
-                    body: JSON.stringify({
-                        deviceName: currCase[0],
-                        description: currCase[1],
-                        number_of_children: currCase[2]
-                    })
-                });
-            }
+            // creates group records as found in above in testCases
+            response = await fetch(`${baseUrl}/createGroup`, {
+                method: "POST",
+                body: JSON.stringify(currCase)
+            });
 
             // last two test cases, 7 & 8, are meant to fail during record creation
             if (i < testCases.length - 2){
@@ -126,7 +110,7 @@ describe("Group Creation v2 tests", () => {
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
                 let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
                 let parentRecord = prov[0].record
-                expect(parentRecord.deviceName).toBe(currCase[0])
+                expect(parentRecord.deviceName).toBe(currCase.deviceName)
                 groupParentRecords.push(parentRecord);
 
                 // stores child keys by group
@@ -135,23 +119,23 @@ describe("Group Creation v2 tests", () => {
                 
                 // retrieves and stores custom child titles by group
                 let tempGroup = []
-                for (let j = 0; j < childKeys.length; j ++) {
+                for (let j = 0; j < currCase.number_of_children; j ++) {
                     let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
                     let childTitle = childProv[0].record.deviceName
                     tempGroup.push(childTitle)
 
                     // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName
-                    if (currCase.length === 4) {
-                        if (j <= currCase[3].length - 1) {
-                            expect(childTitle).toBe(currCase[3][j])
+                    if (currCase.children_name) {
+                        if (j <= currCase.children_name.length - 1) {
+                            expect(childTitle).toBe(currCase.children_name[j])
                         } else {
                             expect(childTitle).toBe("")
                         }
                     } else {
-                        if (currCase[0] === "") {
+                        if (currCase.deviceName === "") {
                             expect(childTitle).toBe("")
                         } else {
-                            expect(childTitle).toBe(`${currCase[0]} #${j + 1}`)
+                            expect(childTitle).toBe(`${currCase.deviceName} #${j + 1}`)
                         }
                     };
                 }

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -121,26 +121,28 @@ describe("Group Creation v2 tests", () => {
 
                 // retrieves and stores parent records and tests that parent deviceName matches test cases
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
-                let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
+                let y = await fetch(`${baseUrl}/provenance/${parentKey}`)
+                let prov = await y.json();
                 let parentRecord = prov[0].record
                 expect(parentRecord.deviceName).toBe(currCase.deviceName)
                 groupParentRecords.push(parentRecord);
 
                 // stores child keys by group
                 let childKeys = parentRecord.children_key
-                console.log(childKeys)
+                console.log("childKeys: ", childKeys)
                 groupedChildKeys.push(childKeys);
                 
                 // retrieves and stores custom child titles by group
                 let tempGroup = []
-                console.log(currCase)
+                console.log("currCase: ", currCase)
                 console.log(currCase.number_of_children)
                 console.log(0 < currCase.number_of_children)
                 for (let j = 0; j < currCase.number_of_children; j ++) {
                     let x = await fetch(`${baseUrl}/provenance/${childKeys[j]}`)
+                    console.log("x: ", x)
                     let childProv = await x.json();
                     let childTitle = childProv[0].record.deviceName
-                    console.log(x, childProv, childTitle)
+                    // console.log(childProv, childTitle)
                     tempGroup.push(childTitle)
 
                     // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -24,8 +24,7 @@ describe("Group of tests", () => {
 describe("Group Creation v2 tests", () => {
     // Tests group child custom titles
 	it("Custom Record Titles", async () => {
-        // "https://gosqasbe.azurewebsites.net/api"
-        // "http://localhost:7071/api"
+        // const baseUrl = "http://localhost:7071/api"
 		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
         const groupParentRecords = []
         const groupedChildKeys = []
@@ -39,62 +38,83 @@ describe("Group Creation v2 tests", () => {
         const testCases = [
             {
                 deviceName: "0th Test",
+                description: "no number_of_children or children_name key"
+            },
+            {
+                deviceName: "1st Test",
+                description: "0 children, 3 custom record titles",
+                number_of_children: 0,
+                children_name: ["a1", "b2", "c3"]
+            },
+            {
+                deviceName: "2nd Test",
+                description: "0 children, no children_name key",
+                number_of_children: 0
+            },
+            {
+                deviceName: "3rd Test",
+                description: "-2 number_of_children, 3 custom record titles",
+                number_of_children: -2,
+                children_name: ["a1", "b2", "c3"]
+            },
+            {
+                deviceName: "4th Test",
                 description: "1 custom record title",
                 number_of_children: 1,
                 children_name: ["a1"]
             },
             {
-                deviceName: "1st Test",
+                deviceName: "5th Test",
                 description: "3 custom record titles",
                 number_of_children: 3,
                 children_name: ["a1", "b2", "c3"]
             },
             {
-                deviceName: "2nd Test",
+                deviceName: "6th Test",
                 description: "3 children, 1 custom record title, 2 records without custom title",
                 number_of_children: 3,
                 children_name: ["a1"]
             },
             {
-                deviceName: "3rd Test",
+                deviceName: "7th Test",
                 description: "3 children, empty children_name array",
                 number_of_children: 3,
                 children_name: []
             },
             {
-                deviceName: "4th Test",
+                deviceName: "8th Test",
                 description: "4 children, no children_name array",
                 number_of_children: 4
             },
             {
                 deviceName: "",
-                description: "5th Test: completely empty parent deviceName string, no children_name array",
+                description: "9th Test: completely empty parent deviceName string, no children_name array",
                 number_of_children: 5
             },
             {
                 deviceName: " ",
-                description: "6th Test: single space as parent deviceName string, no children_name array",
+                description: "10th Test: single space as parent deviceName string, no children_name array",
                 number_of_children: 6
             },
             {
-                deviceName: "7th Test",
+                deviceName: "11th Test",
                 description: "1 child, 3 custom record titles",
                 number_of_children: 1,
                 children_name: ["a1", "b2", "c3"]
             },
             {
-                deviceName: "8th Test",
+                deviceName: "12th Test",
                 description: "no number_of_children key, 3 custom record titles",
                 children_name: ["a1", "b2", "c3"]
             },
             {
-                deviceName: "9th Test",
+                deviceName: "13th Test",
                 description: "non-array children_name value, will fail Zod validation",
                 number_of_children: 3,
                 children_name: "a"
             },
             {
-                deviceName: "10th Test",
+                deviceName: "14th Test",
                 description: "children_name array with unexpected number, will fail Zod validation",
                 number_of_children: 3,
                 children_name: ["a1", 9, "c3"]
@@ -111,7 +131,7 @@ describe("Group Creation v2 tests", () => {
                 body: JSON.stringify(currCase)
             });
 
-            // last two test cases, 9 & 10, are meant to fail during record creation
+            // last two test cases, 13 & 14, are meant to fail during record creation
             if (i < testCases.length - 2){
                 // checks if fetch() response was sucessful (status in 200 - 299)
                 expect(response.ok).toBe(true);
@@ -121,31 +141,20 @@ describe("Group Creation v2 tests", () => {
 
                 // retrieves and stores parent records and tests that parent deviceName matches test cases
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
-                let y = await fetch(`${baseUrl}/provenance/${parentKey}`)
-                console.log("y: ", y)
-                let prov = await y.json();
-                console.log("prov: ", prov)
+                let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
                 let parentRecord = prov[0].record
-                console.log("parentRecord: ", parentRecord)
                 expect(parentRecord.deviceName).toBe(currCase.deviceName)
                 groupParentRecords.push(parentRecord);
 
                 // stores child keys by group
                 let childKeys = parentRecord.children_key
-                console.log("childKeys: ", childKeys)
                 groupedChildKeys.push(childKeys);
                 
                 // retrieves and stores custom child titles by group
                 let tempGroup = []
-                console.log("currCase: ", currCase)
-                console.log(currCase.number_of_children)
-                console.log(0 < currCase.number_of_children)
                 for (let j = 0; j < currCase.number_of_children; j ++) {
-                    let x = await fetch(`${baseUrl}/provenance/${childKeys[j]}`)
-                    console.log("x: ", x)
-                    let childProv = await x.json();
+                    let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
                     let childTitle = childProv[0].record.deviceName
-                    console.log(childProv, childTitle)
                     tempGroup.push(childTitle)
 
                     // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName
@@ -165,7 +174,6 @@ describe("Group Creation v2 tests", () => {
                 }
                 groupedChildTitles.push(tempGroup)
             } else {
-                // console.log(currCase) 
                 expect(response.ok).toBe(false);
             }
         };

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -24,6 +24,8 @@ describe("Group of tests", () => {
 describe("Group Creation v2 tests", () => {
     // Tests group child custom titles
 	it("Custom Record Titles", async () => {
+        // "https://gosqasbe.azurewebsites.net/api"
+        // "http://localhost:7071/api"
 		const baseUrl = "https://gosqasbe.azurewebsites.net/api";
         const groupParentRecords = []
         const groupedChildKeys = []
@@ -126,13 +128,19 @@ describe("Group Creation v2 tests", () => {
 
                 // stores child keys by group
                 let childKeys = parentRecord.children_key
+                console.log(childKeys)
                 groupedChildKeys.push(childKeys);
                 
                 // retrieves and stores custom child titles by group
                 let tempGroup = []
+                console.log(currCase)
+                console.log(currCase.number_of_children)
+                console.log(0 < currCase.number_of_children)
                 for (let j = 0; j < currCase.number_of_children; j ++) {
-                    let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
+                    let x = await fetch(`${baseUrl}/provenance/${childKeys[j]}`)
+                    let childProv = await x.json();
                     let childTitle = childProv[0].record.deviceName
+                    console.log(x, childProv, childTitle)
                     tempGroup.push(childTitle)
 
                     // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName
@@ -151,7 +159,8 @@ describe("Group Creation v2 tests", () => {
                     };
                 }
                 groupedChildTitles.push(tempGroup)
-            } else { 
+            } else {
+                console.log(currCase) 
                 expect(response.ok).toBe(false);
             }
         };

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -33,64 +33,73 @@ describe("Group Creation v2 tests", () => {
 
 	it("Custom Record Titles", async () => {
 		const baseUrl = "http://localhost:7071/api";
-        const customTitles = ["a1", "b2"];
+        const groupParentRecords = []
+        const groupedChildKeys = []
+        const groupedChildTitles = []
+
+        // Test cases are built as follows, note the children_name key can be left out or an empty array used as a value:
+        // [ deviceName,
+        // description,
+        // number_of_children,
+        // children_name ]
         const testCases = [
             [
-                "1st Test",
+                "0th Test",
                 "1 custom record title",
                 1,
                 ["a1"]
             ],
             [
-                "2nd Test",
+                "1st Test",
                 "3 custom record titles",
                 3,
                 ["a1", "b2", "c3"]
             ],
             [
-                "3rd Test",
-                "3 children, 2 custom record titles",
+                "2nd Test",
+                "3 children, 1 custom record title, 2 records without custom title",
                 3,
-                ["a1", "b2"]
+                ["a1"]
             ],
             [
-                "4th Test",
+                "3rd Test",
                 "3 children, empty children_name array",
                 3,
                 []
             ],
             [
-                "5th Test",
-                "3 children, no children_name array",
-                3
+                "4th Test",
+                "4 children, no children_name array",
+                4
             ],
             [
                 "",
-                "6th Test: completely empty parent deviceName string, no children_name array",
-                3
+                "5th Test: completely empty parent deviceName string, no children_name array",
+                5
             ],
             [
                 " ",
-                "7th Test: single space as parent deviceName string, no children_name array",
-                3
+                "6th Test: single space as parent deviceName string, no children_name array",
+                6
             ],
             [
-                "8th Test",
+                "7th Test",
                 "non-array children_name value, will fail Zod validation",
                 3,
                 "a"
             ],
             [
-                "9th Test",
+                "8th Test",
                 "children_name array with unexpected number, will fail Zod validation",
                 3,
                 ["a1", 9, "c3"]
             ]
         ]
-        const groupParentRecords = []
-        let testCase;
-
+        
         for (let i = 0; i < testCases.length; i++) {
+            let testCase;
+
+            // Creates group records based on whether or not test case contains children_name field"
             if (testCases[i].length === 4) {
                 testCase = await fetch(`${baseUrl}/createGroup`, {
                     method: "POST",
@@ -113,21 +122,30 @@ describe("Group Creation v2 tests", () => {
             }
 
             // Checks if fetch() response was sucessful (status in 200 - 299), then prepares to pull children
-            // test case 8 & 9 are meant to fail
+            // test case 7 & 8 are meant to fail
             if (i < 7){
                 expect(testCase.ok).toBe(true);
                 
                 let url = (await testCase.json()).groupUrl;
-                console.log(`Custom title test case #${i + 1}: ${url}`)
+                console.log(`Custom title test case #${i}: ${url}`)
 
-                let key = url.substring(url.lastIndexOf('/') + 1);
-                let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
-                groupParentRecords.push(prov[0].record)
+                let parentKey = url.substring(url.lastIndexOf('/') + 1);
+                let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
+                let parentRecord = prov[0].record
+                groupParentRecords.push(parentRecord);
+
+                let childKeys = parentRecord.children_key
+                groupedChildKeys.push(childKeys);
+                
+                let tempGroup = []
+                for (let j = 0; j < childKeys.length; j ++) {
+                    let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
+                    tempGroup.push(childProv[0].record.deviceName)
+                }
+                groupedChildTitles.push(tempGroup)
             } else { 
                 expect(testCase.ok).toBe(false);
             }
-
-            
         };
 
         // const response = await fetch(`${baseUrl}/createGroup`, {
@@ -158,8 +176,9 @@ describe("Group Creation v2 tests", () => {
         // console.log(prov[0].record);
         // console.log(prov[0].record.children_key[0])
         // console.log(await (await fetch(`${baseUrl}/provenance/${prov[0].record.children_key[0]}`)).json())
-        console.log(groupParentRecords)
-
+        console.log("groupParentRecords: ", groupParentRecords)
+        console.log("groupedChildKeys: ", groupedChildKeys)
+        console.log("groupedChildTitles: ", groupedChildTitles)
 	});
 
 	// More tests

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -143,6 +143,7 @@ describe("Group Creation v2 tests", () => {
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
                 let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
                 let parentRecord = prov[0].record
+                // console.log(parentRecord)
                 expect(parentRecord.deviceName).toBe(currCase.deviceName)
                 groupParentRecords.push(parentRecord);
 
@@ -165,11 +166,7 @@ describe("Group Creation v2 tests", () => {
                             expect(childTitle).toBe("")
                         }
                     } else {
-                        if (currCase.deviceName === "") {
-                            expect(childTitle).toBe("")
-                        } else {
-                            expect(childTitle).toBe(`${currCase.deviceName} #${j + 1}`)
-                        }
+                        expect(childTitle).toBe(`${currCase.deviceName} #${j + 1}`)
                     };
                 }
                 groupedChildTitles.push(tempGroup)

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -122,8 +122,11 @@ describe("Group Creation v2 tests", () => {
                 // retrieves and stores parent records and tests that parent deviceName matches test cases
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
                 let y = await fetch(`${baseUrl}/provenance/${parentKey}`)
+                console.log("y: ", y)
                 let prov = await y.json();
+                console.log("prov: ", prov)
                 let parentRecord = prov[0].record
+                console.log("parentRecord: ", parentRecord)
                 expect(parentRecord.deviceName).toBe(currCase.deviceName)
                 groupParentRecords.push(parentRecord);
 
@@ -142,7 +145,7 @@ describe("Group Creation v2 tests", () => {
                     console.log("x: ", x)
                     let childProv = await x.json();
                     let childTitle = childProv[0].record.deviceName
-                    // console.log(childProv, childTitle)
+                    console.log(childProv, childTitle)
                     tempGroup.push(childTitle)
 
                     // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName
@@ -162,7 +165,7 @@ describe("Group Creation v2 tests", () => {
                 }
                 groupedChildTitles.push(tempGroup)
             } else {
-                console.log(currCase) 
+                // console.log(currCase) 
                 expect(response.ok).toBe(false);
             }
         };

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -22,22 +22,14 @@ describe("Group of tests", () => {
 */
 
 describe("Group Creation v2 tests", () => {
-	// it("Brief description that this tests foo", () => {
-	// 	var val = do_thing();
-	// 	expect(val).toBe(0);
-	// });
-
-	// it("Brief description that this tests bar", () => {
-	// 	// structured similar to above
-	// });
-
+    // Tests group child custom titles
 	it("Custom Record Titles", async () => {
 		const baseUrl = "http://localhost:7071/api";
         const groupParentRecords = []
         const groupedChildKeys = []
         const groupedChildTitles = []
 
-        // Test cases are built as follows, note the children_name key can be left out or an empty array used as a value:
+        // Test cases are structured as follows, note the children_name key can be left out, an empty array used as a value, or less than number_of_children:
         // [ deviceName,
         // description,
         // number_of_children,
@@ -97,41 +89,43 @@ describe("Group Creation v2 tests", () => {
         ]
         
         for (let i = 0; i < testCases.length; i++) {
-            let testCase;
+            let currCase = testCases[i];
+            let response;
 
             // Creates group records based on whether or not test case contains children_name field"
-            if (testCases[i].length === 4) {
-                testCase = await fetch(`${baseUrl}/createGroup`, {
+            if (currCase.length === 4) {
+                response = await fetch(`${baseUrl}/createGroup`, {
                     method: "POST",
                     body: JSON.stringify({
-                        deviceName: testCases[i][0],
-                        description: testCases[i][1],
-                        number_of_children: testCases[i][2],
-                        children_name: testCases[i][3]
+                        deviceName: currCase[0],
+                        description: currCase[1],
+                        number_of_children: currCase[2],
+                        children_name: currCase[3]
                     })
                 });
             } else {
-                testCase = await fetch(`${baseUrl}/createGroup`, {
+                response = await fetch(`${baseUrl}/createGroup`, {
                     method: "POST",
                     body: JSON.stringify({
-                        deviceName: testCases[i][0],
-                        description: testCases[i][1],
-                        number_of_children: testCases[i][2]
+                        deviceName: currCase[0],
+                        description: currCase[1],
+                        number_of_children: currCase[2]
                     })
                 });
             }
 
             // Checks if fetch() response was sucessful (status in 200 - 299), then prepares to pull children
-            // test case 7 & 8 are meant to fail
-            if (i < 7){
-                expect(testCase.ok).toBe(true);
+            // last two test cases, 7 & 8, are meant to fail
+            if (i < testCases.length - 2){
+                expect(response.ok).toBe(true);
                 
-                let url = (await testCase.json()).groupUrl;
+                let url = (await response.json()).groupUrl;
                 console.log(`Custom title test case #${i}: ${url}`)
 
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
                 let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
                 let parentRecord = prov[0].record
+                expect(parentRecord.deviceName).toBe(currCase[0])
                 groupParentRecords.push(parentRecord);
 
                 let childKeys = parentRecord.children_key
@@ -140,42 +134,30 @@ describe("Group Creation v2 tests", () => {
                 let tempGroup = []
                 for (let j = 0; j < childKeys.length; j ++) {
                     let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
-                    tempGroup.push(childProv[0].record.deviceName)
+                    let childTitle = childProv[0].record.deviceName
+                    tempGroup.push(childTitle)
+
+                    if (currCase.length === 4) {
+                        if (j <= currCase[3].length - 1) {
+                            expect(childTitle).toBe(currCase[3][j])
+                        } else {
+                            expect(childTitle).toBe("")
+                        }
+                    } else {
+                        if (currCase[0] === "") {
+                            // console.log(currCase[1])
+                            expect(childTitle).toBe("")
+                        } else {
+                            expect(childTitle).toBe(`${currCase[0]} #${j + 1}`)
+                        }
+                    };
                 }
                 groupedChildTitles.push(tempGroup)
             } else { 
-                expect(testCase.ok).toBe(false);
+                expect(response.ok).toBe(false);
             }
         };
 
-        // const response = await fetch(`${baseUrl}/createGroup`, {
-        //     method: "POST",
-        //     body: JSON.stringify({
-        //         deviceName: "Group Title",
-        //         description: "Group Description",
-        //         number_of_children: 3,
-        //         children_name: customTitles
-        //     })
-        // });
-
-        // let url = (await response.json()).groupUrl;
-        // let key = url.substring(url.lastIndexOf('/') + 1);
-        // let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
-
-        // // TODO: delete below
-        // console.log("int test:", url);
-        // console.log("resp:", response);
-        // console.log(response.ok);
-        // console.log(response.body);
-        // console.log(response.status);
-        // console.log(response.headers);
-        // // console.log(await response.text())
-        // console.log(url);
-        // console.log(key);
-
-        // console.log(prov[0].record);
-        // console.log(prov[0].record.children_key[0])
-        // console.log(await (await fetch(`${baseUrl}/provenance/${prov[0].record.children_key[0]}`)).json())
         console.log("groupParentRecords: ", groupParentRecords)
         console.log("groupedChildKeys: ", groupedChildKeys)
         console.log("groupedChildTitles: ", groupedChildTitles)

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -33,19 +33,73 @@ describe("Group Creation v2 tests", () => {
 
 	it("Custom Record Titles", async () => {
 		const baseUrl = "http://localhost:7071/api";
-        const customTitles = ["a1", "b2", "c3"];
+        const customTitles = ["a1", "b2"];
+        const testCases = [
+            [
+                "1st Test",
+                "1 custom record title",
+                1,
+                ["a1"]
+            ],
+            [
+                "2nd Test",
+                "3 custom record titles",
+                3,
+                ["a1", "b2", "c3"]
+            ],
+            [
+                "3rd Test",
+                "3 children, 2 custom record titles",
+                3,
+                ["a1", "b2"]
+            ],
+            [
+                "4th Test",
+                "3 children, no custom record titles",
+                3
+            ],
+            [
+                "5th Test",
+                "3 children, empty children_name array",
+                3,
+                []
+            ]
+            
+        ]
+
+        // for (let i = 0; i < groupRecords.length; i++) {
+
+        // };
 
         const response = await fetch(`${baseUrl}/createGroup`, {
             method: "POST",
             body: JSON.stringify({
                 deviceName: "Group Title",
                 description: "Group Description",
-                number_of_children: 5,
+                number_of_children: 3,
                 children_name: customTitles
-            }) 
+            })
         });
 
-        console.log("test:", await response.json())
+        let url = (await response.json()).groupUrl;
+        let key = url.substring(url.lastIndexOf('/') + 1);
+        let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
+
+        // TODO: delete below
+        console.log("int test:", url);
+        console.log("resp:", response);
+        console.log(response.ok);
+        console.log(response.body);
+        console.log(response.status);
+        console.log(response.headers);
+        // console.log(await response.text())
+        console.log(url);
+        console.log(key);
+
+        console.log(prov[0].record);
+        console.log(prov[0].record.children_key[0])
+        console.log(await (await fetch(`${baseUrl}/provenance/${prov[0].record.children_key[0]}`)).json())
+
 	});
 
 	// More tests

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -92,7 +92,7 @@ describe("Group Creation v2 tests", () => {
             let currCase = testCases[i];
             let response;
 
-            // Creates group records based on whether or not test case contains children_name field"
+            // Creates group records based on whether or not test case contains children_name field
             if (currCase.length === 4) {
                 response = await fetch(`${baseUrl}/createGroup`, {
                     method: "POST",
@@ -114,29 +114,33 @@ describe("Group Creation v2 tests", () => {
                 });
             }
 
-            // Checks if fetch() response was sucessful (status in 200 - 299), then prepares to pull children
-            // last two test cases, 7 & 8, are meant to fail
+            // last two test cases, 7 & 8, are meant to fail during record creation
             if (i < testCases.length - 2){
+                // checks if fetch() response was sucessful (status in 200 - 299)
                 expect(response.ok).toBe(true);
                 
                 let url = (await response.json()).groupUrl;
                 console.log(`Custom title test case #${i}: ${url}`)
 
+                // retrieves and stores parent records and tests that parent deviceName matches test cases
                 let parentKey = url.substring(url.lastIndexOf('/') + 1);
                 let prov = await (await fetch(`${baseUrl}/provenance/${parentKey}`)).json();
                 let parentRecord = prov[0].record
                 expect(parentRecord.deviceName).toBe(currCase[0])
                 groupParentRecords.push(parentRecord);
 
+                // stores child keys by group
                 let childKeys = parentRecord.children_key
                 groupedChildKeys.push(childKeys);
                 
+                // retrieves and stores custom child titles by group
                 let tempGroup = []
                 for (let j = 0; j < childKeys.length; j ++) {
                     let childProv = await (await fetch(`${baseUrl}/provenance/${childKeys[j]}`)).json();
                     let childTitle = childProv[0].record.deviceName
                     tempGroup.push(childTitle)
 
+                    // tests that retrieved custom child titles match test cases based on existence, length, and contents of children_name key and parent deviceName
                     if (currCase.length === 4) {
                         if (j <= currCase[3].length - 1) {
                             expect(childTitle).toBe(currCase[3][j])
@@ -145,7 +149,6 @@ describe("Group Creation v2 tests", () => {
                         }
                     } else {
                         if (currCase[0] === "") {
-                            // console.log(currCase[1])
                             expect(childTitle).toBe("")
                         } else {
                             expect(childTitle).toBe(`${currCase[0]} #${j + 1}`)
@@ -157,10 +160,9 @@ describe("Group Creation v2 tests", () => {
                 expect(response.ok).toBe(false);
             }
         };
-
-        console.log("groupParentRecords: ", groupParentRecords)
-        console.log("groupedChildKeys: ", groupedChildKeys)
-        console.log("groupedChildTitles: ", groupedChildTitles)
+        // console.log("groupParentRecords: ", groupParentRecords)
+        // console.log("groupedChildKeys: ", groupedChildKeys)
+        // console.log("groupedChildTitles: ", groupedChildTitles)
 	});
 
 	// More tests

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -76,12 +76,23 @@ describe("Group Creation v2 tests", () => {
             },
             {
                 deviceName: "7th Test",
+                description: "1 child, 3 custom record titles",
+                number_of_children: 1,
+                children_name: ["a1", "b2", "c3"]
+            },
+            {
+                deviceName: "8th Test",
+                description: "no number_of_children key, 3 custom record titles",
+                children_name: ["a1", "b2", "c3"]
+            },
+            {
+                deviceName: "9th Test",
                 description: "non-array children_name value, will fail Zod validation",
                 number_of_children: 3,
                 children_name: "a"
             },
             {
-                deviceName: "8th Test",
+                deviceName: "10th Test",
                 description: "children_name array with unexpected number, will fail Zod validation",
                 number_of_children: 3,
                 children_name: ["a1", 9, "c3"]
@@ -98,7 +109,7 @@ describe("Group Creation v2 tests", () => {
                 body: JSON.stringify(currCase)
             });
 
-            // last two test cases, 7 & 8, are meant to fail during record creation
+            // last two test cases, 9 & 10, are meant to fail during record creation
             if (i < testCases.length - 2){
                 // checks if fetch() response was sucessful (status in 200 - 299)
                 expect(response.ok).toBe(true);

--- a/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/create.test.ts
@@ -55,50 +55,110 @@ describe("Group Creation v2 tests", () => {
             ],
             [
                 "4th Test",
-                "3 children, no custom record titles",
-                3
-            ],
-            [
-                "5th Test",
                 "3 children, empty children_name array",
                 3,
                 []
+            ],
+            [
+                "5th Test",
+                "3 children, no children_name array",
+                3
+            ],
+            [
+                "",
+                "6th Test: completely empty parent deviceName string, no children_name array",
+                3
+            ],
+            [
+                " ",
+                "7th Test: single space as parent deviceName string, no children_name array",
+                3
+            ],
+            [
+                "8th Test",
+                "non-array children_name value, will fail Zod validation",
+                3,
+                "a"
+            ],
+            [
+                "9th Test",
+                "children_name array with unexpected number, will fail Zod validation",
+                3,
+                ["a1", 9, "c3"]
             ]
-            
         ]
+        const groupParentRecords = []
+        let testCase;
 
-        // for (let i = 0; i < groupRecords.length; i++) {
+        for (let i = 0; i < testCases.length; i++) {
+            if (testCases[i].length === 4) {
+                testCase = await fetch(`${baseUrl}/createGroup`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        deviceName: testCases[i][0],
+                        description: testCases[i][1],
+                        number_of_children: testCases[i][2],
+                        children_name: testCases[i][3]
+                    })
+                });
+            } else {
+                testCase = await fetch(`${baseUrl}/createGroup`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        deviceName: testCases[i][0],
+                        description: testCases[i][1],
+                        number_of_children: testCases[i][2]
+                    })
+                });
+            }
 
-        // };
+            // Checks if fetch() response was sucessful (status in 200 - 299), then prepares to pull children
+            // test case 8 & 9 are meant to fail
+            if (i < 7){
+                expect(testCase.ok).toBe(true);
+                
+                let url = (await testCase.json()).groupUrl;
+                console.log(`Custom title test case #${i + 1}: ${url}`)
 
-        const response = await fetch(`${baseUrl}/createGroup`, {
-            method: "POST",
-            body: JSON.stringify({
-                deviceName: "Group Title",
-                description: "Group Description",
-                number_of_children: 3,
-                children_name: customTitles
-            })
-        });
+                let key = url.substring(url.lastIndexOf('/') + 1);
+                let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
+                groupParentRecords.push(prov[0].record)
+            } else { 
+                expect(testCase.ok).toBe(false);
+            }
 
-        let url = (await response.json()).groupUrl;
-        let key = url.substring(url.lastIndexOf('/') + 1);
-        let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
+            
+        };
 
-        // TODO: delete below
-        console.log("int test:", url);
-        console.log("resp:", response);
-        console.log(response.ok);
-        console.log(response.body);
-        console.log(response.status);
-        console.log(response.headers);
-        // console.log(await response.text())
-        console.log(url);
-        console.log(key);
+        // const response = await fetch(`${baseUrl}/createGroup`, {
+        //     method: "POST",
+        //     body: JSON.stringify({
+        //         deviceName: "Group Title",
+        //         description: "Group Description",
+        //         number_of_children: 3,
+        //         children_name: customTitles
+        //     })
+        // });
 
-        console.log(prov[0].record);
-        console.log(prov[0].record.children_key[0])
-        console.log(await (await fetch(`${baseUrl}/provenance/${prov[0].record.children_key[0]}`)).json())
+        // let url = (await response.json()).groupUrl;
+        // let key = url.substring(url.lastIndexOf('/') + 1);
+        // let prov = await (await fetch(`${baseUrl}/provenance/${key}`)).json();
+
+        // // TODO: delete below
+        // console.log("int test:", url);
+        // console.log("resp:", response);
+        // console.log(response.ok);
+        // console.log(response.body);
+        // console.log(response.status);
+        // console.log(response.headers);
+        // // console.log(await response.text())
+        // console.log(url);
+        // console.log(key);
+
+        // console.log(prov[0].record);
+        // console.log(prov[0].record.children_key[0])
+        // console.log(await (await fetch(`${baseUrl}/provenance/${prov[0].record.children_key[0]}`)).json())
+        console.log(groupParentRecords)
 
 	});
 

--- a/packages/backend/test/IntegrationTests/Live/v2/temp.txt
+++ b/packages/backend/test/IntegrationTests/Live/v2/temp.txt
@@ -1,1 +1,0 @@
-Needed to create empty folder; deleteme


### PR DESCRIPTION
From #919.

Extends the API v2 createRecord operation to include custom record titles for group children and includes integration tests for this.
Can be used like so:
```
curl -X 'POST' \
  'https://gosqasbe.azurewebsites.net/api/createGroup' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "deviceName": "Group Title",
  "description": "Group Description",
  "number_of_children": 3,
  "children_name": ["a1", "b2", "c3"]
}'
```

Custom record titles currently operate in this manner:

- Custom record titles must be prepared as an array of strings. The "children_name" key will ONLY accept either an empty array or an array of strings as its value.
- Custom titles included in the children_name array will be used as child record deviceName during group record creation.
- children_name array can have less custom titles than the number of child records specified by number_of_children. This will create child records with custom titles only up to the number of titles specified, any other children will have blank titles.
- children_name can contain more titles than number_of children. This will create children with custom titles up to number_of_child and discard any extra titles.
- If there are number_of_children specified and no children_name key present, each child will be created with the parent's deviceName + an incrementing record number as their title.
~~-- A parent deviceName consisting of a completely empty string "" will create children with blank titles.~~
- Creating a group with a missing number_of_children key and a children_name array will not create children.