### PR TITLE
Changed code in postdeployment integration tests to reflect new 2MB attachment size limit

### DIFF
--- a/packages/backend/test/IntegrationTests/Live/v1/writeAttachments.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v1/writeAttachments.test.ts
@@ -275,38 +275,20 @@ describe("Creating records with attachments", () => {
             body: formData,
             });
 
-            expect(postResponse.ok).toBe(true);
-            console.log('Large file upload succeeded');
+            expect(postResponse.ok).toBe(false);
+            console.log('Large file upload failed as expected');
 
         } catch (error) {
             console.error("(Create POST Test - Large File) Error creating a record: " + error); 
             throw error;
         }
 
-        // GET record key to make sure it exists with large attachment
+        // GET record key to make sure it doesn't exist with large attachement
         let getResponse; 
         try {
             getResponse = await fetch(fullUrl);
             getResponse = await getResponse.json();
-            let responseString = JSON.parse(JSON.stringify(getResponse[0]));
-
-            expect(JSON.stringify(getResponse)).not.toBe('[]');
-            expect(responseString.record.deviceName).toBe('Create Record Test - Large File');
-            expect(responseString.record.description).toBe('An API Feature Test - Large Attachment (>2MB)');
-            expect(responseString.attachments.length).toBe(1);
-
-            // Download and compare large attachment
-            const attachmentHash = responseString.attachments[0];
-            const downloadUrl = `https://gdtprodbackend.azurewebsites.net/api/attachment/${deviceKey}/${attachmentHash}`;
-            console.log('Downloading large file from:', downloadUrl);
-            const downloadResponse = await fetch(downloadUrl);
-            expect(downloadResponse.ok).toBe(true);
-            const retrievedBuffer = Buffer.from(await downloadResponse.arrayBuffer());
-            
-            // Reading original large file 
-            const originalBuffer = await readFile('./test/attachments/LargeFile.pdf');
-            expect(Buffer.compare(originalBuffer, retrievedBuffer)).toBe(0);
-            console.log('Large file attachment matches original');
+            expect(JSON.stringify(getResponse)).toBe('[]');
 
         } catch(error) {
             console.error('(Create GET Test - Large File) Failed to fetch url: ' + fullUrl + '\nError: ' + error) 


### PR DESCRIPTION
Decided to make a separate issue to circumvent weird moved file issue and also this way it's easier to keep track of this issue.

Reversed test code to reflect new changes in codebase (2MB file attachment limit) and allow backend pull requests to pass this portion of the test.