### PR TITLE
Updated History Page Wording

### DIFF
--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -29,11 +29,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 placeholder="Description" maxlength="5000" rows="3"></textarea>
             <div v-if="isGroup">
                 <input type="text" class="form-control" name="children-key" id="children-key" v-model="childKeyText"
-                    placeholder="Group Record Keys (optional, separated with a comma)" />
+                    placeholder="Add Children by Key (optional, comma separated list)" />
             </div>
             <div v-else>
                 <input type="text" class="form-control" name="container-key" id="container-key" v-model="groupKey"
-                    placeholder="Group Key (optional)" />
+                    placeholder="Add to Group (key, optional)" />
             </div>
 
             <div>


### PR DESCRIPTION
Changed "Group Key (optional)" -> "Add to Group (key, optional)" and "Group Record Keys (optional, separated with a comma)" -> "Add Children by Key (optional, comma separated list)".

<img width="982" height="637" alt="Screenshot 2026-04-14 at 5 57 34 PM" src="https://github.com/user-attachments/assets/815abb0d-44a9-4560-9277-9fe3c8e38b7b" />
<img width="979" height="553" alt="Screenshot 2026-04-14 at 5 58 03 PM" src="https://github.com/user-attachments/assets/ca841693-c121-417a-aee2-5888dc2f1c23" />
