### PR TITLE
Added Back Learn More Component

### DIFF
--- a/packages/frontend/pages/data-privacy.vue
+++ b/packages/frontend/pages/data-privacy.vue
@@ -56,6 +56,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 </template>
 
 <script lang="ts">
+import Learn_more from '~/layouts/learn_more.vue';
 import jsQR from 'jsqr';
 import { ref } from 'vue'
 


### PR DESCRIPTION
During a merge the learn more component was lost on the Data Privacy page, so I added it back.