### PR TITLE
Fixed Loading Not Going Away on Failure

### DIFF
--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -380,6 +380,7 @@ export default {
                     type: 'error',
                     text: `Error creating the group: ${error}`
                 })
+                EventBus.emit('isLoading')
             }
 
             

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -241,6 +241,7 @@ export default {
                     type: 'error',
                     text: `Failed to create record: ${error}`
                 });
+                EventBus.emit('isLoading');
             } finally {
                 this.isSubmitting = false;
             }

--- a/packages/frontend/pages/gdt.vue
+++ b/packages/frontend/pages/gdt.vue
@@ -89,7 +89,20 @@ export default {
     mounted() {
         // switch to loading screen when a form is submitted
         EventBus.on('isLoading', () => {
-            this.isLoading = true;
+            if (!this.isLoading) {
+                this.isLoading = true;
+                return
+            }
+            this.isLoading = false;
+        })
+    },
+    beforeUnmount() {
+        EventBus.off('isLoading', () => {
+            if (!this.isLoading) {
+                this.isLoading = true;
+                return
+            }
+            this.isLoading = false;
         })
     },
     methods: {

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -292,7 +292,7 @@ async mounted() {
         console.log(error)
 	}
 },
-beforeDestroy() {
+beforeUnmount() {
 	EventBus.off('feedRefresh', this.refreshFeed);
 	EventBus.off('isCreating', () => {
 	if (!this.isCreating) {

--- a/packages/frontend/pages/record/[deviceKey].vue
+++ b/packages/frontend/pages/record/[deviceKey].vue
@@ -61,7 +61,7 @@ const recordHasParent = hasParent(provenance);
                         <button class="btn px-3 device-btn view-history" @click="viewRecord">View History Records</button>
                         <button class="btn px-3 device-btn download-qr" @click="downloadQRCode">Download QR Code</button>
                         <ProvenanceShareDropdown :deviceName="deviceRecord.deviceName" :description="deviceRecord.description"></ProvenanceShareDropdown>
-                        <EmailNotificationSignup :recordKey="_recordKey" :fontSize="18" :height="61" :width="48"></EmailNotificationSignup>
+                        <EmailNotificationSignup :recordKey="_recordKey" :fontSize="18" :height="61"></EmailNotificationSignup>
                     </div>
 
                     <!-- QR -->


### PR DESCRIPTION
Modified createRecord and createContainer to loop back to the creation page if they fail to create (for group it only loops back if the group fails to create, if child or reporting key fails it just displays error in a snackbar). They still display the snackbar saying the error received.