### PR TITLE
Added line to solve local CORS issue when offline

### DIFF
--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -215,7 +215,7 @@ export async function onlineTestFetch(url?: string): Promise<boolean> {
     }
 
     try {
-        let response = await fetch(url);
+        let response = await fetch(url, { cache: 'no-store'});
         if (response.status !== 200) {
             result = false;
 


### PR DESCRIPTION
Because of our PWA feature, the service worker caches all of our pages and thus even when offline, the fetch function calls our frontend url, which is cached so it will return 200, even though we are offline. This line tells the browser not to look into our cache for the request and instead make a real network request instead. This resolves the CORS issue when trying to ping either Google which returns a CORS error or when calling our frontend url, which returns a 200 status due to our pages being cached, which we don't want when offline because it bypasses the important offline code block to enter offline mode.