### PR TITLE
Changed 2MB attachment size limit to 5MB per DMDM Request

### DIFF
--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -56,7 +56,7 @@ interface NamedBlob {
     blob: Blob,
 }
 
-const MAX_ATTACHMENT_SIZE = 2 * 1024 * 1024; // 2MB
+const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024; // 5MB
 
 function findDeviceIdFromName(blobName: string): string {
     // blobNames look like: 'gosqas/63f4b781c0688d83d40908ff368fefa6a2fa4cd470216fd83b3d7d4c642578c0/prov/1a771caa4b15a45ae97b13d7a336e1e9c9ec1c91c70f1dc8f7749440c0af8114'

--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -209,7 +209,7 @@ export default {
 
             if (!files || files.length === 0) return;
 
-            const maxFileSize = 2097152;  // aka 2MB
+            const maxFileSize = 5242880;  // aka 5MB
 
             let validFileSize = true;
 

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -177,7 +177,7 @@ export default {
 
             if (!files || files.length === 0) return;
 
-            const maxFileSize = 2097152;  // aka 2MB
+            const maxFileSize = 5242880;  // aka 5MB
 
             let validFileSize = true;
 

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -239,7 +239,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
             if (!files || files.length === 0) return;
 
-            const maxFileSize = 2097152;
+            const maxFileSize = 5242880; // 5MB
 
             let validFileSize = true;
 


### PR DESCRIPTION
Changed 2MB attachment size limit to 5MB in the frontend and backend.