### PR TITLE
Improved emptyStash Function

### DIFF
--- a/packages/frontend/pages/history/offline.vue
+++ b/packages/frontend/pages/history/offline.vue
@@ -35,7 +35,7 @@ their items while offline.
                 <div class="my-4 text-iris fs-1">
                 <p class="text-bold mb-0 device-name">Asset History Records</p>
                 <h1 class="mt-1 mb-1" style="word-break: break-word;">
-                    Offline Creation Page
+                    Offline: Add to Existing Record
                 </h1>
                 </div>
                 <div class="rec">

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -276,16 +276,21 @@ export async function stashRequest(formUrl: string, formData: FormData) {
 }
 
 async function stashKeysAndRemove(fullUrl: string, stashName: string, request_name: string, stash_counter: number) {
-    let keys = [];
-    let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
-    let existingKeys = localStorage.getItem(stashName)
-    if (existingKeys) {
-        for (const key of existingKeys.split(",")) {
-            keys.push(key)
+    try {
+        let keys = [];
+        let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
+        let existingKeys = localStorage.getItem(stashName)
+        if (existingKeys) {
+            for (const key of existingKeys.split(",")) {
+                keys.push(key)
+            }
         }
+        keys.push(currentKey)
+        localStorage.setItem(stashName, keys.toString())
+
+    } catch (error) {
+        console.log("Record from localStorage was not able to be stashed: " + error)
     }
-    keys.push(currentKey)
-    localStorage.setItem(stashName, keys.toString())
 
     // Remove request from stash and update counter
     localStorage.removeItem(request_name)

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -275,6 +275,19 @@ export async function stashRequest(formUrl: string, formData: FormData) {
     }
 }
 
+async function stashKeys(fullUrl: string, stashName: string) {
+    let keys = [];
+    let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
+    let existingKeys = localStorage.getItem(stashName)
+    if (existingKeys) {
+        for (const key of existingKeys.split(",")) {
+            keys.push(key)
+        }
+    }
+    keys.push(currentKey)
+    localStorage.setItem(stashName, keys.toString())
+}
+
 export async function emptyStash() {
     // See how many requests are stored, if any
     let stash_counter = parseInt(localStorage.getItem('stash_counter') || "0");
@@ -283,7 +296,6 @@ export async function emptyStash() {
         // Get the last request stored
         let request_name = 'gosqas_offline_stash_' + stash_counter;
         let request = JSON.parse(localStorage.getItem(request_name) || '{}');
-        // If request is empty, delete it and move onto the next one
         if (request === '{}') { 
             localStorage.removeItem(request_name)
             localStorage.setItem('stash_counter', (stash_counter - 1).toString())
@@ -293,42 +305,22 @@ export async function emptyStash() {
         let record = request[1][1];
 
         try {
-            // Fulfill the request (this will throw an error if it fails)
+            // Fulfill the request and confirm it was created (this will throw an error if it fails)
             const formData = new FormData();
             formData.append('provenanceRecord', record);
             let response = await fetchUrl(fullUrl, formData)
             response = await fetchUrl(fullUrl)
 
             // Add created key to a list of successfully created keys to display later
-            let keysCreated = [];
-            let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1]
-            let existingKeys = localStorage.getItem("gdt-stash-fulfilled")
-            if (existingKeys) {
-                for (const key of existingKeys.split(",")) {
-                    keysCreated.push(key)
-                }
-            }
-            keysCreated.push(currentKey)
-            localStorage.setItem("gdt-stash-fulfilled", keysCreated.toString())
+            stashKeys(fullUrl, "gdt-stash-fulfilled")
 
             // Remove request from stash and update counter
             localStorage.removeItem(request_name)
             localStorage.setItem('stash_counter', (stash_counter - 1).toString());
         } catch (error) {
-            // If the record fails to create for any reason other than being offline, add it to the failed stash.
             if (await(onlineTestFetch())) {
-                let keysFailed = [];
-                let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1]
-                let existingKeys = localStorage.getItem("gdt-stash-failed")
-                if (existingKeys) {
-                    for (const key of existingKeys.split(",")) {
-                        keysFailed.push(key)
-                    }
-                }
-                keysFailed.push(currentKey)
-                localStorage.setItem("gdt-stash-failed", keysFailed.toString())
-
-                // Remove request from stash and update counter
+                // If the record fails to create for any reason other than being offline, add it to the failed stash
+                stashKeys(fullUrl, "gdt-stash-failed")
                 localStorage.removeItem(request_name)
                 localStorage.setItem('stash_counter', (stash_counter - 1).toString());
             }

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -275,7 +275,7 @@ export async function stashRequest(formUrl: string, formData: FormData) {
     }
 }
 
-async function stashKeys(fullUrl: string, stashName: string) {
+async function stashKeysAndRemove(fullUrl: string, stashName: string, request_name: string, stash_counter: number) {
     let keys = [];
     let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
     let existingKeys = localStorage.getItem(stashName)
@@ -286,6 +286,10 @@ async function stashKeys(fullUrl: string, stashName: string) {
     }
     keys.push(currentKey)
     localStorage.setItem(stashName, keys.toString())
+
+    // Remove request from stash and update counter
+    localStorage.removeItem(request_name)
+    localStorage.setItem('stash_counter', (stash_counter - 1).toString());
 }
 
 export async function emptyStash() {
@@ -308,31 +312,27 @@ export async function emptyStash() {
             // Fulfill the request and confirm it was created (this will throw an error if it fails)
             const formData = new FormData();
             formData.append('provenanceRecord', record);
-            let response = await fetchUrl(fullUrl, formData)
-            response = await fetchUrl(fullUrl)
+
+            await fetchUrl(fullUrl, formData);  // fetchUrl POST handles retries/errors
+            let response = await fetchUrl(fullUrl);  // fetchUrl GET returns [] if no record is found
+            if ((await response.json()).length == 0) { throw new Error('Record failed to POST') }
 
             // Add created key to a list of successfully created keys to display later
-            stashKeys(fullUrl, "gdt-stash-fulfilled")
-
-            // Remove request from stash and update counter
-            localStorage.removeItem(request_name)
-            localStorage.setItem('stash_counter', (stash_counter - 1).toString());
+            stashKeysAndRemove(fullUrl, "gdt-stash-fulfilled", request_name, stash_counter)
         } catch (error) {
+            // If the record fails to create for any reason other than being offline, add it to the failed stash
             if (await(onlineTestFetch())) {
-                // If the record fails to create for any reason other than being offline, add it to the failed stash
-                stashKeys(fullUrl, "gdt-stash-failed")
-                localStorage.removeItem(request_name)
-                localStorage.setItem('stash_counter', (stash_counter - 1).toString());
+                stashKeysAndRemove(fullUrl, "gdt-stash-failed", request_name, stash_counter)
             }
 
             console.log("Record from localStorage failed to create: " + error)
         }
 
-        // Check if user is still online before trying to create more records
         if (!await(onlineTestFetch())) {
             return 202;
         }
     }
+
     // Disable the offline banner and enable the online banner
     displayOfflineBanner = false;
     // Online banner currently doesn't have a way to be disabled, so we'll avoid enabling it until that is implemented

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -280,18 +280,24 @@ export async function emptyStash() {
     let stash_counter = parseInt(localStorage.getItem('stash_counter') || "0");
 
     for (stash_counter; stash_counter > 0; stash_counter--) {
-        try {
-            // Get the last request stored
-            let request_name = 'gosqas_offline_stash_' + stash_counter;
-            let request = JSON.parse(localStorage.getItem(request_name) || '{}');
-            let fullUrl = request[0][1];
-            let record = request[1][1];
+        // Get the last request stored
+        let request_name = 'gosqas_offline_stash_' + stash_counter;
+        let request = JSON.parse(localStorage.getItem(request_name) || '{}');
+        // If request is empty, delete it and move onto the next one
+        if (request === '{}') { 
+            localStorage.removeItem(request_name)
+            localStorage.setItem('stash_counter', (stash_counter - 1).toString())
+            continue
+        }
+        let fullUrl = request[0][1];
+        let record = request[1][1];
 
-            // Fulfill the request
+        try {
+            // Fulfill the request (this will throw an error if it fails)
             const formData = new FormData();
             formData.append('provenanceRecord', record);
             let response = await fetchUrl(fullUrl, formData)
-            if (response.status != 200) { throw new Error(`Fetch failed with error code ${response.status}`) }
+            response = await fetchUrl(fullUrl)
 
             // Add created key to a list of successfully created keys to display later
             let keysCreated = [];
@@ -309,8 +315,30 @@ export async function emptyStash() {
             localStorage.removeItem(request_name)
             localStorage.setItem('stash_counter', (stash_counter - 1).toString());
         } catch (error) {
+            // If the record fails to create for any reason other than being offline, add it to the failed stash.
+            if (await(onlineTestFetch())) {
+                let keysFailed = [];
+                let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1]
+                let existingKeys = localStorage.getItem("gdt-stash-failed")
+                if (existingKeys) {
+                    for (const key of existingKeys.split(",")) {
+                        keysFailed.push(key)
+                    }
+                }
+                keysFailed.push(currentKey)
+                localStorage.setItem("gdt-stash-failed", keysFailed.toString())
+
+                // Remove request from stash and update counter
+                localStorage.removeItem(request_name)
+                localStorage.setItem('stash_counter', (stash_counter - 1).toString());
+            }
+
             console.log("Record from localStorage failed to create: " + error)
-            return 404;
+        }
+
+        // Check if user is still online before trying to create more records
+        if (!await(onlineTestFetch())) {
+            return 202;
         }
     }
     // Disable the offline banner and enable the online banner

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -275,7 +275,7 @@ export async function stashRequest(formUrl: string, formData: FormData) {
     }
 }
 
-async function stashKeysAndRemove(fullUrl: string, stashName: string, request_name: string, stash_counter: number) {
+async function stashKeysAndRemove(fullUrl: string, stashName: string, request_name: string, stash_counter: number, request: string) {
     try {
         let keys = [];
         let currentKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
@@ -289,6 +289,8 @@ async function stashKeysAndRemove(fullUrl: string, stashName: string, request_na
         localStorage.setItem(stashName, keys.toString())
 
     } catch (error) {
+        // If the request can't be formatted properly to stash, then just stash the whole thing in failed
+        localStorage.setItem("gdt-stash-failed", request)
         console.log("Record from localStorage was not able to be stashed: " + error)
     }
 
@@ -323,11 +325,11 @@ export async function emptyStash() {
             if ((await response.json()).length == 0) { throw new Error('Record failed to POST') }
 
             // Add created key to a list of successfully created keys to display later
-            stashKeysAndRemove(fullUrl, "gdt-stash-fulfilled", request_name, stash_counter)
+            stashKeysAndRemove(fullUrl, "gdt-stash-fulfilled", request_name, stash_counter, request)
         } catch (error) {
             // If the record fails to create for any reason other than being offline, add it to the failed stash
             if (await(onlineTestFetch())) {
-                stashKeysAndRemove(fullUrl, "gdt-stash-failed", request_name, stash_counter)
+                stashKeysAndRemove(fullUrl, "gdt-stash-failed", request_name, stash_counter, request)
             }
 
             console.log("Record from localStorage failed to create: " + error)

--- a/packages/frontend/test/unitTests/azureFuncs.spec.ts
+++ b/packages/frontend/test/unitTests/azureFuncs.spec.ts
@@ -117,6 +117,7 @@ describe('Tests to see if we can remove from the stash', () => {
     // Mock fetch calls from emptyStash (since formData doesn't work from this file)
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
       status: 200,
+      json: () => Promise.resolve({ record: "mockRecord" }),
     } as Response);
 
     const key = await makeEncodedDeviceKey();
@@ -151,6 +152,7 @@ describe('Tests to see if we can remove from the stash', () => {
   it('Create and remove two requests', async () => {
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
       status: 200,
+      json: () => Promise.resolve({ record: "mockRecord" }),
     } as Response);
 
     const key1 = await makeEncodedDeviceKey();
@@ -203,31 +205,34 @@ describe('Tests to see if we can remove from the stash', () => {
     expect(statusCode).toEqual(200);
   });
 
-  it("Make sure record isn't removed from localStorage when post fails", async () => {
+  it("Make sure record is added to failed stash when post fails", async () => {
     const key = await makeEncodedDeviceKey();
     let [formUrl, formData] = await createRequest(key, 'failed record', 'this should fail to post');
 
     localStorage.setItem('stash_counter', '0');
     localStorage.setItem('gdt-stash-fulfilled', '');
+    localStorage.setItem('gdt-stash-failed', '');
     stashRequest(formUrl, formData);
     expect(localStorage.getItem('stash_counter')).toEqual('1');
 
     // Empty the stash without mocking (so it will fail to post since formData cannot be posted from this file)
     console.log('Attempting a failed fetch to check error handling...');
     let statusCode = await emptyStash();
-    expect(statusCode).toEqual(404);
+    expect(statusCode).toEqual(200);
 
-    // Make sure the record is still in the stash and the counter still = 1
+    // Make sure the record is still no longer in the stash
     const request = JSON.parse(localStorage.getItem('gosqas_offline_stash_1') || '{}');
-    expect(request).not.toEqual(null);
-    expect(request[0][1]).toEqual(formUrl);
-    expect(JSON.parse(request[1][1]).deviceName).toEqual('failed record');
-    expect(JSON.parse(request[1][1]).description).toEqual('this should fail to post');
-    expect(request[1][1]).toStrictEqual(formData.get('provenanceRecord'));
-    expect(localStorage.getItem('stash_counter')).toEqual('1');
+    expect(request).toEqual({});
+    expect(localStorage.getItem('stash_counter')).toEqual('0');
+
+    // Confirm the failed key was added to list of failed requests
+    let existingKeys = (localStorage.getItem('gdt-stash-failed') || '{}').split(',');
+    expect(existingKeys).not.toEqual(['{}']);
+    expect(existingKeys.length).toBe(1);
+    expect(existingKeys[0]).toEqual(formUrl.split('/')[formUrl.split('/').length - 1]);
 
     // Confirm failed key was not added to list of successful requests
-    let existingKeys = (localStorage.getItem('gdt-stash-fulfilled') || '{}').split(',');
+    existingKeys = (localStorage.getItem('gdt-stash-fulfilled') || '{}').split(',');
     expect(existingKeys).toEqual(['{}']);
   }, 200000);
 });
@@ -236,6 +241,7 @@ describe("Tests to see if periodicChecker works", async () => {
   it ("Create a record from periodicChecker", async () => {
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
       status: 200,
+      json: () => Promise.resolve({ record: "mockRecord" }),
     } as Response);
 
     const key = await makeEncodedDeviceKey();
@@ -243,6 +249,7 @@ describe("Tests to see if periodicChecker works", async () => {
 
     localStorage.setItem('stash_counter', '0');  // reset the counter to avoid overlap with other tests
     localStorage.setItem('gdt-stash-fulfilled', '');
+    localStorage.setItem('gdt-stash-failed', '');
     stashRequest(formUrl, formData);
     expect(localStorage.getItem('stash_counter')).toEqual('1');
 


### PR DESCRIPTION
Implemented the requested changes for the emptyStash function:
- If the stashed request is empty: delete the request, update the counter, and go to the next request
- Function now tries to get the created record, and if that or creation fails it goes to the catch block
- If in the catch block the user is online, add the record to the failed stash, delete the request, and update the counter (since if the record failed to create and the user is online, then something unrelated to offline went wrong)
- If something went wrong and the user if offline, simply continue to the end of the loop without removing the record
- At the end of every loop checks if the user is still online, exiting the function if they are not
- If a record cannot be formatted to stash in either fulfilled or failed the whole string will be put into the failed stash

I also updated the name of the Offline Creation Page to Offline: Add to Existing Record, as discussed in the meeting.