### PR TITLE
Redirect When Creating Records Offline

### DIFF
--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -388,8 +388,7 @@ export default {
             } catch (error) {
                 // If the user is offline navigate to the offline history page instead
                 if (!(await onlineTestFetch())) {
-                    const frontendUrl = useRuntimeConfig().public.frontendUrl;
-                    window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
+                    await this.$router.push({ path: `/history/offline`, query: { key: deviceKey }});
                 }
 
                 this.$snackbar.add({

--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -387,9 +387,7 @@ export default {
                 }
             } catch (error) {
                 // If the user is offline navigate to the offline history page instead
-                // Only do this if they are using the PWA, since when purely offline the page won't load
-                let inPWA = window.matchMedia('(display-mode: standalone)').matches;
-                if (!(await onlineTestFetch()) && inPWA) {
+                if (!(await onlineTestFetch())) {
                     const frontendUrl = useRuntimeConfig().public.frontendUrl;
                     window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
                 }

--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -130,7 +130,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
  </template>
 
 <script lang="ts">
-import { postProvenance, postEmail, displayOnlineBanner, displayOfflineBanner, postNotificationEmail } from '~/services/azureFuncs';
+import { postProvenance, postEmail, displayOnlineBanner, displayOfflineBanner, postNotificationEmail, onlineTestFetch } from '~/services/azureFuncs';
 import { makeEncodedDeviceKey } from '~/utils/keyFuncs';
 import { validateFileSize } from '~/utils/fileSizeValidation';
 import { ref } from 'vue';
@@ -386,10 +386,20 @@ export default {
                     })
                 }
             } catch (error) {
+                // If the user is offline navigate to the offline history page instead
+                // Only do this if they are using the PWA, since when purely offline the page won't load
+                let inPWA = window.matchMedia('(display-mode: standalone)').matches;
+                if (!(await onlineTestFetch()) && inPWA) {
+                    const frontendUrl = useRuntimeConfig().public.frontendUrl;
+                    window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
+                }
+
                 this.$snackbar.add({
                     type: 'error',
                     text: `Error creating the group: ${error}`
                 })
+
+                // Otherwise just return to the /gdt page
                 EventBus.emit('isLoading')
             }
 

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -250,8 +250,7 @@ export default {
             } catch (error) {
                 // If the user is offline navigate to the offline history page instead
                 if (!(await onlineTestFetch())) {
-                    const frontendUrl = useRuntimeConfig().public.frontendUrl;
-                    window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
+                    await this.$router.push({ path: `/history/offline`, query: { key: deviceKey }});
                 }
 
                 this.$snackbar.add({

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -117,7 +117,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 
 <script lang="ts">
-import { postProvenance, postEmail, displayOnlineBanner, displayOfflineBanner, postNotificationEmail } from '~/services/azureFuncs';
+import { postProvenance, postEmail, displayOnlineBanner, displayOfflineBanner, postNotificationEmail, onlineTestFetch } from '~/services/azureFuncs';
 import { makeEncodedDeviceKey } from '~/utils/keyFuncs';
 import { validateFileSize } from '~/utils/fileSizeValidation';
 import Banner from '../Banner.vue';
@@ -206,10 +206,10 @@ export default {
             EventBus.emit('isLoading');
 
             if (this.isSubmitting) return;
-            
             this.isSubmitting = true;
+
+            const deviceKey = await makeEncodedDeviceKey();
             try {
-                const deviceKey = await makeEncodedDeviceKey();
                 const response = await postProvenance(deviceKey, {
                     blobType: 'deviceInitializer',
                     deviceName: this.name,
@@ -248,10 +248,20 @@ export default {
 
                 }
             } catch (error) {
+                // If the user is offline navigate to the offline history page instead
+                // Only do this if they are using the PWA, since when purely offline the page won't load
+                let inPWA = window.matchMedia('(display-mode: standalone)').matches;
+                if (!(await onlineTestFetch()) && inPWA) {
+                    const frontendUrl = useRuntimeConfig().public.frontendUrl;
+                    window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
+                }
+
                 this.$snackbar.add({
                     type: 'error',
                     text: `Failed to create record: ${error}`
                 });
+
+                // Otherwise just return to the /gdt page
                 EventBus.emit('isLoading');
             } finally {
                 this.isSubmitting = false;

--- a/packages/frontend/components/Forms/CreateDevice.vue
+++ b/packages/frontend/components/Forms/CreateDevice.vue
@@ -249,9 +249,7 @@ export default {
                 }
             } catch (error) {
                 // If the user is offline navigate to the offline history page instead
-                // Only do this if they are using the PWA, since when purely offline the page won't load
-                let inPWA = window.matchMedia('(display-mode: standalone)').matches;
-                if (!(await onlineTestFetch()) && inPWA) {
+                if (!(await onlineTestFetch())) {
                     const frontendUrl = useRuntimeConfig().public.frontendUrl;
                     window.location.assign(`${frontendUrl}/history/offline?key=${deviceKey}`);
                 }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -277,8 +277,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         async redirectIfOffline() {
             // If the user is offline navigate to the offline history page instead
             if (!(await onlineTestFetch())) {
-                const frontendUrl = useRuntimeConfig().public.frontendUrl;
-                window.location.assign(`${frontendUrl}/history/offline?key=${this.recordKey}`);
+                await this.$router.push({ path: `/history/offline`, query: { key: this.recordKey }});
             }
         },
         async submitRecord() {

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -276,9 +276,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         },
         async redirectIfOffline() {
             // If the user is offline navigate to the offline history page instead
-            // Only do this if they are using the PWA, since when purely offline the page won't load
-            let inPWA = window.matchMedia('(display-mode: standalone)').matches;
-            if (!(await onlineTestFetch()) && inPWA) {
+            if (!(await onlineTestFetch())) {
                 const frontendUrl = useRuntimeConfig().public.frontendUrl;
                 window.location.assign(`${frontendUrl}/history/offline?key=${this.recordKey}`);
             }

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -147,7 +147,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
  </template>
 
  <script lang="ts">
- import { postProvenance, getProvenance, displayOfflineBanner, displayOnlineBanner, postNotificationEmail } from '~/services/azureFuncs';
+ import { postProvenance, getProvenance, displayOfflineBanner, displayOnlineBanner, postNotificationEmail, onlineTestFetch } from '~/services/azureFuncs';
  import { EventBus } from '~/utils/event-bus';
  import { addChildKeys, addToGroup, notifyChildren, recallChildren } from '~/utils/descendantList';
  import { validateKey } from '~/utils/keyFuncs';
@@ -274,6 +274,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             this.annotatePopUp = false;
             this.recallPopUp = false;
         },
+        async redirectIfOffline() {
+            // If the user is offline navigate to the offline history page instead
+            // Only do this if they are using the PWA, since when purely offline the page won't load
+            let inPWA = window.matchMedia('(display-mode: standalone)').matches;
+            if (!(await onlineTestFetch()) && inPWA) {
+                const frontendUrl = useRuntimeConfig().public.frontendUrl;
+                window.location.assign(`${frontendUrl}/history/offline?key=${this.recordKey}`);
+            }
+        },
         async submitRecord() {
             // Emit an event to notify the history/[deviceKey].vue page to display loading screen
             EventBus.emit('isCreating');
@@ -283,6 +292,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             try {
                 records = await getProvenance(this.recordKey);
             } catch (e) {
+                this.redirectIfOffline()
                 EventBus.emit('isCreating');
             }
 
@@ -303,6 +313,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                         await addToGroup(this.recordKey, this.groupKey, records, groupRecords);
                     } catch (error) {
                         console.error('Error adding to group:', error);
+                        this.redirectIfOffline()
                         this.$snackbar.add({
                             type: 'error',
                             text: `Error adding to group: ${error}`
@@ -341,6 +352,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                     }
                 }
             } catch (error: any) {
+                console.error('Error adding children:', error);
+                this.redirectIfOffline()
                 const badKeys = error.message.split(",");
                 
                 if (error.message.split(" ").length > badKeys.length) {
@@ -397,6 +410,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 EventBus.emit('feedRefresh');
 
             } catch (error) {
+                this.redirectIfOffline()
                 this.$snackbar.add({
                     type: 'error',
                     text: `Error creating record: ${error}`

--- a/packages/frontend/pages/gdt.vue
+++ b/packages/frontend/pages/gdt.vue
@@ -86,7 +86,7 @@ export default {
             toggled: true
         }
     },
-    mounted() {
+    async mounted() {
         // switch to loading screen when a form is submitted
         EventBus.on('isLoading', () => {
             if (!this.isLoading) {
@@ -95,6 +95,9 @@ export default {
             }
             this.isLoading = false;
         })
+
+        // preload the offline history page (so we can navigate to this page if the user goes offline)
+        await import('./history/offline.vue');
     },
     beforeUnmount() {
         EventBus.off('isLoading', () => {

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -291,6 +291,9 @@ async mounted() {
             this.isCreating = false;
         });
 
+		// preload the offline history page (so we can navigate to this page if the user goes offline)
+        await import('./offline.vue');
+
         await this.refreshFeed();
 	} catch (error) {
         this.isCreating = false;

--- a/packages/frontend/pages/history/offline.vue
+++ b/packages/frontend/pages/history/offline.vue
@@ -156,7 +156,6 @@ async mounted() {
         const route = useRoute();
         this.recordKey = route.query.key as string;
         
-
         EventBus.on('feedRefresh', this.refreshFeed);
 
         await this.refreshFeed();
@@ -250,6 +249,7 @@ methods: {
                 type: 'error',
                 text: `Error creating record: ${error}`
             });
+            this.refresh()
             this.isCreating = false;
         }
     },

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -214,7 +214,7 @@ async function fetchUrl(url: string, formData?: FormData) {
 export async function onlineTestFetch(url?: string): Promise<boolean> {
     let result = true;
 
-    // This is added to make testing easier, if no parameter given -> defaults to pinging Google.
+    // This is added to make testing easier, if no parameter given -> defaults to pinging our frontend.
     // Given parameter can be bogus url to mock offlineness
     if (url === undefined) {
         url = useRuntimeConfig().public.frontendUrl;


### PR DESCRIPTION
If you create a record from any of the three creation pages while offline you will now be redirected to the offline history page. When you're redirected the key will autofill (since redirects only happen on record creation only the key is sent, since the rest of the information is stashed to be created once the user comes back online).

To make vue's router work offline we needed to preload the offline history page, which has the added benefit of making sure the page will load offline when redirected to (even outside the PWA).

<img width="737" height="337" alt="Screenshot 2026-05-29 at 3 38 31 PM" src="https://github.com/user-attachments/assets/860f0d44-99d8-461a-9c27-60ea95c77d46" />