### PR TITLE
Periodic Checker Falsely Skipping

### DIFF
--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -16,7 +16,7 @@
 import { validateKey } from "~/utils/keyFuncs";
 
 // Feature flag to turn ON/OFF Offline Mode features while in development
-export var offlineModeFeatureFlag = true;
+export var offlineModeFeatureFlag = false;
 
 // Global variable used to control the display of offline banner on create pages
 export var displayOfflineBanner = false;
@@ -25,13 +25,6 @@ export var displayOfflineBanner = false;
 export var displayOnlineBanner = false;
 
 localStorage.setItem('gdt-awaiting-connectivity', 'false')
-
-console.log("AT START")
-console.log("STASH_COUNTER: " + localStorage.getItem('stash_counter'))
-console.log("STASH_COUNTER NUMBER TYPE: " + typeof(localStorage.getItem('stash_counter')))
-window.addEventListener("load", () => {
-    console.log("LOADED ON PAGE LOAD")
-})
 
 // method takes the base58 encoded device key
 export async function getProvenance(deviceKey: string) {
@@ -250,7 +243,6 @@ export async function onlineTestFetch(url?: string): Promise<boolean> {
 export async function connectivityChecker() {
     // While offlineTestFetch returns false, test for onlineness every 5 seconds. Return when back online (offlineTestFetch returns true)
     while (!(await onlineTestFetch())) {
-        console.log("INSIDE CONNECTIVITY CHECKER")
         await new Promise((r) => setTimeout(r, 5000));
     }
 

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { LazyButtonsLargeToggle } from "#components";
 import { validateKey } from "~/utils/keyFuncs";
 
 // Feature flag to turn ON/OFF Offline Mode features while in development
@@ -23,6 +24,8 @@ export var displayOfflineBanner = false;
 
 // Global variable used to control the display of online banner 
 export var displayOnlineBanner = false;
+
+localStorage.setItem('gdt-awaiting-connectivity', 'false')
 
 // method takes the base58 encoded device key
 export async function getProvenance(deviceKey: string) {
@@ -181,7 +184,6 @@ export async function getStatistics() {
 async function fetchUrl(url: string, formData?: FormData) {
     let response = undefined;
     const MAX_RETRIES = 3;
-
     for (let i = 1; i <= MAX_RETRIES; i++) {
         try {
             if (typeof formData !== 'undefined') {
@@ -278,7 +280,6 @@ export async function stashRequest(formUrl: string, formData: FormData) {
 export async function emptyStash() {
     // See how many requests are stored, if any
     let stash_counter = parseInt(localStorage.getItem('stash_counter') || "0");
-
     for (stash_counter; stash_counter > 0; stash_counter--) {
         try {
             // Get the last request stored
@@ -322,11 +323,13 @@ export async function emptyStash() {
 
 export async function periodicChecker() {
     // Return if a checker is already running
-    if (localStorage.getItem('gdt-awaiting-conectivity') == "true") {
+    if (localStorage.getItem('gdt-awaiting-connectivity') == "true") {
         console.log("Instance of periodicChecker is already running, returning")
         return;
     }
-    localStorage.setItem('gdt-awaiting-conectivity', "true");
+
+    // Sets toggle true to prevent multiple instances of connectivityChecker running
+    localStorage.setItem('gdt-awaiting-connectivity', "true");
 
     let stash_empty = false;
     let response = 404
@@ -337,10 +340,10 @@ export async function periodicChecker() {
         response = await emptyStash();
         if (response == 200) {
             stash_empty = true;
+            // Back online, set to false prevent being blocked out in the first block of code in this function
+            localStorage.setItem('gdt-awaiting-connectivity', "false")
         }
     }
-
-    localStorage.setItem('gdt-awaiting-conectivity', "false");
 }
 
 export async function offlineDetectAndStash (formUrl: string, formData: FormData) {

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { LazyButtonsLargeToggle } from "#components";
 import { validateKey } from "~/utils/keyFuncs";
 
 // Feature flag to turn ON/OFF Offline Mode features while in development

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -16,7 +16,7 @@
 import { validateKey } from "~/utils/keyFuncs";
 
 // Feature flag to turn ON/OFF Offline Mode features while in development
-export var offlineModeFeatureFlag = false;
+export var offlineModeFeatureFlag = true;
 
 // Global variable used to control the display of offline banner on create pages
 export var displayOfflineBanner = false;
@@ -25,6 +25,13 @@ export var displayOfflineBanner = false;
 export var displayOnlineBanner = false;
 
 localStorage.setItem('gdt-awaiting-connectivity', 'false')
+
+console.log("AT START")
+console.log("STASH_COUNTER: " + localStorage.getItem('stash_counter'))
+console.log("STASH_COUNTER NUMBER TYPE: " + typeof(localStorage.getItem('stash_counter')))
+window.addEventListener("load", () => {
+    console.log("LOADED ON PAGE LOAD")
+})
 
 // method takes the base58 encoded device key
 export async function getProvenance(deviceKey: string) {
@@ -243,6 +250,7 @@ export async function onlineTestFetch(url?: string): Promise<boolean> {
 export async function connectivityChecker() {
     // While offlineTestFetch returns false, test for onlineness every 5 seconds. Return when back online (offlineTestFetch returns true)
     while (!(await onlineTestFetch())) {
+        console.log("INSIDE CONNECTIVITY CHECKER")
         await new Promise((r) => setTimeout(r, 5000));
     }
 
@@ -349,6 +357,7 @@ export async function offlineDetectAndStash (formUrl: string, formData: FormData
     try {
         // Check if the user is online or offline. Stash the request if the user is offline
         if ((await(onlineTestFetch()))) {
+            localStorage.setItem('gdt-awaiting-connectivity', "false")
             return 200;
         } else {
             await stashRequest(formUrl, formData);

--- a/packages/frontend/test/unitTests/azureFuncs.spec.ts
+++ b/packages/frontend/test/unitTests/azureFuncs.spec.ts
@@ -255,7 +255,7 @@ describe("Tests to see if periodicChecker works", async () => {
     // Make sure the record was removed from the stash and the new key was stored to display later
     expect(localStorage.getItem('stash_counter')).toEqual('0');
     expect(localStorage.getItem('gosqas_offline_stash_1')).toEqual(null);
-    expect(localStorage.getItem('gdt-awaiting-conectivity')).toEqual("false");
+    expect(localStorage.getItem('gdt-awaiting-connectivity')).toEqual("false");
 
     let existingKeys = (localStorage.getItem('gdt-stash-fulfilled') || '{}').split(',');
     expect(existingKeys).not.toEqual(['{}']);
@@ -275,7 +275,7 @@ describe("Tests to see if periodicChecker works", async () => {
     await new Promise((r) => setTimeout(r, 5000));
 
     // Confirm that the checker is still running, even after a few seconds
-    expect(localStorage.getItem('gdt-awaiting-conectivity')).toEqual("true");
+    expect(localStorage.getItem('gdt-awaiting-connectivity')).toEqual("true");
 
     fetchMock.mockRestore();
   });
@@ -292,7 +292,7 @@ describe("Tests to see if periodicChecker works", async () => {
 
     // Confirm the "already running" message was sent and that the first call is still running
     expect(consoleMock).toHaveBeenCalledWith('Instance of periodicChecker is already running, returning');
-    expect(localStorage.getItem('gdt-awaiting-conectivity')).toEqual("true");
+    expect(localStorage.getItem('gdt-awaiting-connectivity')).toEqual("true");
 
     consoleMock.mockRestore();
     fetchMock.mockRestore();


### PR DESCRIPTION
- Added line to fix bug where when periodicChecker is running and the tab is closed. 'gdt-awaiting-connectivity' will now start as 'false' when a new tab is opened so that it can when another record is created periodicChecker won't think it's already running due to the if-clause in its function.

- Changed 'gdt-awaiting-connectivity' to false after the stash is emptied periodicChecker upon online detection and a successful onlineTestFetch call when the user is back online. 

-  Added extra n to 'gdt-awaiting-conectivity' in azureFuncs.spect.ts to align and pass the tests.
