### PR TITLE
Updated text for EmailNotificationSignup button

### DIFF
--- a/packages/frontend/components/EmailNotificationSignup.vue
+++ b/packages/frontend/components/EmailNotificationSignup.vue
@@ -1,6 +1,6 @@
 <template>
     <button class="btn px-3 notify-btn device-btn" :style="btnStyles" @click="openDialog">
-      Get email notifications
+      Sign up for Email Notifications
     </button>
 
     <div v-if="showDialog" class="email-dialog-overlay" @click.self="closeDialog">


### PR DESCRIPTION
Updated the EmailNotificationSignup button text to "Sign up for Email Notifications" to improve clarity.

<img width="953" height="332" alt="Screenshot 2026-06-18 at 3 19 16 PM" src="https://github.com/user-attachments/assets/63f052c6-ece5-4254-9262-a16c295972c9" />
<img width="957" height="335" alt="Screenshot 2026-06-18 at 3 18 51 PM" src="https://github.com/user-attachments/assets/2e1719cf-eb8f-4968-b344-3e0bcce7840c" />
