### PR TITLE
Multiline Display of Record Descriptions When Line Breaks Are Used

### DIFF
--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -70,7 +70,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
             <div class="text"
                 style="font-family: 'Poppins', sans-serif; font-weight: 400; font-size: 20px; line-height: 30px;">
-                <span v-html="clickableLink(report.record?.description)" style="word-break: break-word;"></span>
+                <span v-html="clickableLink(report.record?.description)" style="white-space: pre-wrap;"></span>
             </div>
 
             <div class="mb-1 tag-container">

--- a/packages/frontend/components/Provenance/Feed.vue
+++ b/packages/frontend/components/Provenance/Feed.vue
@@ -56,7 +56,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <div v-for="(report, index) in filteredProvenanceDeviceInit" class="device-creation-box">
 
             <template v-if="report.record.blobType === 'deviceInitializer'">
-                <h3 id="createdDevicePoint" style="word-break: break-word;">Created Record: {{ report.record.deviceName }}</h3>
+                <h3 id="createdDevicePoint" style="white-space:pre-wrap;">Created Record: {{ report.record.deviceName }}</h3>
             </template>
 
             <div v-if="recalledRecord">
@@ -202,7 +202,7 @@ export default {
     margin-bottom: 14px;
     margin-top: 14px;
     border-radius: 20px;
-    word-wrap: break-word;
+    white-space: pre-wrap;
 }
 .device-creation-box {
     display:block;

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -129,7 +129,7 @@ const recordHasParent = hasParent(provenance);
 				<div class="rec" v-else>Record Key: {{ _recordKey }}</div>
 
 				<div class="mb-3 rec">
-				<span v-html="clickableLink(deviceRecord?.description)" style="word-break: break-word;"></span>
+				<span v-html="clickableLink(deviceRecord?.description)" style="white-space: pre-wrap;"></span>
 				</div>
 
 				<section ref="section" id="priority-notices">

--- a/packages/frontend/pages/record/[deviceKey].vue
+++ b/packages/frontend/pages/record/[deviceKey].vue
@@ -48,7 +48,7 @@ const recordHasParent = hasParent(provenance);
                             <div class="h5" v-else>Record Key: {{ _recordKey }}</div>
 
                             <div class="mb-3">
-                                <span id="desc" v-html="clickableLink(deviceRecord?.description)" style="word-break: break-word;"></span>
+                                <span id="desc" v-html="clickableLink(deviceRecord?.description)" style="white-space: pre-wrap;"></span>
                             </div>
                         </div>
 


### PR DESCRIPTION
Added code to preserve and display multi-line descriptions when line breaks are used. The user mentioned multiline in tags also but not too sure whether we should implement that or if possible.

<img width="1947" height="1900" alt="history" src="https://github.com/user-attachments/assets/48dbd6eb-be75-477b-b7a1-ef842267b16b" />
<img width="2971" height="1326" alt="testing1" src="https://github.com/user-attachments/assets/194c4c84-047d-41b2-a637-19b1259d97ef" />
