### PR TITLE
added attachment in doc specs for non-group record creation

### DIFF
--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -1511,24 +1511,23 @@ const RecordCreationOrderSchema = z.object({
 
 export async function createRecordHandler(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
     try{
-        let theRequest = await request.json()
-        RecordCreationOrderSchema.parse(theRequest['provenanceRecord']);
-        let name = theRequest['provenanceRecord']['deviceName'];
-        let description = theRequest['provenanceRecord']['description'];
-        let tags = theRequest['provenanceRecord']['tags'];
-        let attachment = theRequest['attachment'];
+        const formData = await request.formData();
+        const recordStr = formData.get("provenanceRecord");
+        if (typeof recordStr !== "string") {
+            throw new SyntaxError("Missing provenanceRecord in form data");
+        }
+
+        let theRequest = JSON.parse(recordStr);
+        RecordCreationOrderSchema.parse(theRequest);
+        let name = theRequest['deviceName'];
+        let description = theRequest['description'];
+        let tags = theRequest['tags'];
 
         // if there's an attachment create a blob to add to the record
         const attachments = new Array<NamedBlob>();
-        if (attachment != "") {
-            attachment = theRequest['attachment']['file'];
-            let attachmentName = theRequest['attachment']['name'];
-            let bufferAttachment = Buffer.from(attachment, "base64");  // convert base64 string to buffer
-            const blob = new Blob([bufferAttachment], { type: 'image/jpeg' });
-            if (typeof blob !== 'string') {
-                console.log("attach type: " + typeof(blob))
-                attachments.push({ blob: blob, name: attachmentName });
-            }
+        for (const value of formData.values()) {
+            if (typeof value === "string") continue;
+            attachments.push({ name: value.name || "attachment", blob: value });
         }
 
         let recordUrl = await createRecord(context, name, description, tags, attachments)

--- a/packages/backend/test/IntegrationTests/Live/v1/createRecord.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v1/createRecord.test.ts
@@ -13,9 +13,10 @@ describe("Backend Record Creation Tests", () => {
             hasParent: false,
             isReportingKey: false,
         }
-        const postValues = { "provenanceRecord": record, "attachment": [] }
+        const formData = new FormData();
+        formData.append("provenanceRecord", JSON.stringify(record));
 
-        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: JSON.stringify(postValues) });
+        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: formData });
         expect(recordResponse.status).toBe(200)
 
         let recordUrl = (await recordResponse.json()).recordUrl;
@@ -52,9 +53,10 @@ describe("Backend Record Creation Tests", () => {
             hasParent: false,
             isReportingKey: false,
         }
-        const postValues = { "provenanceRecord": record, "attachment": [] }
+        const formData = new FormData();
+        formData.append("provenanceRecord", JSON.stringify(record));
 
-        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: JSON.stringify(postValues) });
+        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: formData });
         expect(recordResponse.status).toBe(200)
 
         let recordUrl = (await recordResponse.json()).recordUrl;
@@ -91,16 +93,12 @@ describe("Backend Record Creation Tests", () => {
             isReportingKey: false,
         }
 
-        // read the file and convert it to base64 string
         const buffer = await readFile('./test/attachments/a200.jpg');
-        let base64string = buffer.toString("base64");
-        const attachment = {
-            name: "kirby.jpg",
-            file: base64string
-        }
+        const formData = new FormData();
+        formData.append("provenanceRecord", JSON.stringify(record));
+        formData.append("kirby.jpg", new Blob([new Uint8Array(buffer)], { type: 'image/jpeg' }), "kirby.jpg");
 
-        const postValues = { "provenanceRecord": record, "attachment": attachment }
-        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: JSON.stringify(postValues) });
+        const recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: formData });
         expect(recordResponse.status).toBe(200);
 
         let recordUrl = (await recordResponse.json()).recordUrl;
@@ -150,8 +148,9 @@ describe("Backend Record Creation Tests", () => {
             isReportingKey: false,
         }
 
-        const postValues = { "provenanceRecord": record, "attachment": [] }
-        let recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: JSON.stringify(postValues) });
+        const formData1 = new FormData();
+        formData1.append("provenanceRecord", JSON.stringify(record));
+        let recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: formData1 });
         expect(recordResponse.status).toBe(400);
 
         // create a record that's missing an optional field and confirm it succeeds (blobType)
@@ -164,8 +163,9 @@ describe("Backend Record Creation Tests", () => {
             isReportingKey: false,
         }
 
-        const postValues2 = { "provenanceRecord": record2, "attachment": [] }
-        recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: JSON.stringify(postValues2) });
+        const formData2 = new FormData();
+        formData2.append("provenanceRecord", JSON.stringify(record2));
+        recordResponse = await fetch(`${baseUrl}createRecord`, { method: "POST", body: formData2 });
         expect(recordResponse.status).toBe(200);
 
         let recordUrl = (await recordResponse.json()).recordUrl;

--- a/packages/frontend/public/GDT-OpenAPI-Spec.yaml
+++ b/packages/frontend/public/GDT-OpenAPI-Spec.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: Auto-generated OpenAPI specification
 servers:
- - url: http://localhost:7071/api
+#  - url: http://localhost:7071/api
 #    description: Local development server
-  # - url: https://gosqasbe.azurewebsites.net/api
+  - url: https://gosqasbe.azurewebsites.net/api
   #   description: Staging server
 #  - url: https://gdtprodbackend.azurewebsites.net/api
 #    description: Production server

--- a/packages/frontend/public/GDT-OpenAPI-Spec.yaml
+++ b/packages/frontend/public/GDT-OpenAPI-Spec.yaml
@@ -4,10 +4,10 @@ info:
   version: 1.0.0
   description: Auto-generated OpenAPI specification
 servers:
-#  - url: http://localhost:7071/api
+ - url: http://localhost:7071/api
 #    description: Local development server
-  - url: https://gosqasbe.azurewebsites.net/api
-    description: Staging server
+  # - url: https://gosqasbe.azurewebsites.net/api
+  #   description: Staging server
 #  - url: https://gdtprodbackend.azurewebsites.net/api
 #    description: Production server
 paths:
@@ -136,7 +136,7 @@ paths:
         description: Record creation parameters in postProvenance
         required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
               type: object
               required:
@@ -160,20 +160,11 @@ paths:
                       description: Group key for grouped records, or empty string for standalone records.
                       example: ""
                 attachment:
-                  oneOf:
-                    - type: string
-                      example: ""
-                    - type: object
-                      required:
-                        - file
-                        - name
-                      properties:
-                        file:
-                          type: string
-                          description: Base64-encoded attachment content
-                        name:
-                          type: string
-                          example: "photo.jpg"
+                  type: array
+                  description: Optional binary files attached to the form data.
+                  items:
+                    type: string
+                    format: binary 
       responses:
         '200':
           description: Successful creation


### PR DESCRIPTION
Added attachment to non-group record spec

Here is an example of how the `/createRecord` endpoint executes on the specs page:

<img width="1918" height="920" alt="recording_non_group_record-optimize" src="https://github.com/user-attachments/assets/8063d96c-e166-4148-bb21-8b79fa9190d7" />

