### PR TITLE
Disable "Add To Group" UI element for records that already have a parent

### DIFF
--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -149,7 +149,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
  <script lang="ts">
  import { postProvenance, getProvenance, displayOfflineBanner, displayOnlineBanner, postNotificationEmail, onlineTestFetch } from '~/services/azureFuncs';
  import { EventBus } from '~/utils/event-bus';
- import { addChildKeys, addToGroup, hasParent, notifyChildren, recallChildren } from '~/utils/descendantList';
+ import { addChildKeys, addToGroup, notifyChildren, recallChildren } from '~/utils/descendantList';
  import { validateKey } from '~/utils/keyFuncs';
  import { validateFileSize } from '~/utils/fileSizeValidation';
  import Banner from '../Banner.vue';

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -31,7 +31,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 <input type="text" class="form-control" name="children-key" id="children-key" v-model="childKeyText"
                     placeholder="Add Children by Key (optional, comma separated list)" />
             </div>
-            <div v-else>
+            <div v-if="!isChild">
                 <input type="text" class="form-control" name="container-key" id="container-key" v-model="groupKey"
                     placeholder="Add to Group (key, optional)" />
             </div>
@@ -149,7 +149,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
  <script lang="ts">
  import { postProvenance, getProvenance, displayOfflineBanner, displayOnlineBanner, postNotificationEmail, onlineTestFetch } from '~/services/azureFuncs';
  import { EventBus } from '~/utils/event-bus';
- import { addChildKeys, addToGroup, notifyChildren, recallChildren } from '~/utils/descendantList';
+ import { addChildKeys, addToGroup, hasParent, notifyChildren, recallChildren } from '~/utils/descendantList';
  import { validateKey } from '~/utils/keyFuncs';
  import { validateFileSize } from '~/utils/fileSizeValidation';
  import Banner from '../Banner.vue';
@@ -209,6 +209,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 return false;
             }
         },
+        // Checks whether record is a child, disables 'Add to Group' field if is a child
+        isChild(): boolean {
+            return Boolean(this.deviceRecord?.hasParent)
+        }
     },
     methods: {
         closePopUpA() {

--- a/packages/frontend/components/Provenance/CreateRecord.vue
+++ b/packages/frontend/components/Provenance/CreateRecord.vue
@@ -210,8 +210,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             }
         },
         // Checks whether record is a child, disables 'Add to Group' field if is a child
-        isChild(): boolean {
-            return Boolean(this.deviceRecord?.hasParent)
+        isChild() {
+            return this.deviceRecord?.hasParent
         }
     },
     methods: {


### PR DESCRIPTION
Added code to only display UI element 'Add to Group' when a record doesn't have a parent.

Parent Key:
<img width="2840" height="1827" alt="parent" src="https://github.com/user-attachments/assets/0c7718b5-35c0-4963-8121-dc4fce0f5eea" />

Child Key:
<img width="2934" height="1821" alt="child" src="https://github.com/user-attachments/assets/7303c9ec-b960-4c4e-8a76-b12a5eb64784" />
