### PR TITLE
Stop PWA from intercepting openapi spec yaml

### DIFF
--- a/packages/frontend/nuxt.config.ts
+++ b/packages/frontend/nuxt.config.ts
@@ -84,7 +84,8 @@ frontendUrl: ${nuxt.options.runtimeConfig.public.frontendUrl}`);
     },
     workbox: {
       globPatterns: ['**/*.{js,css,html,png,svg,ico,vue,mjs}'],
-      maximumFileSizeToCacheInBytes: 5 * 1024 ** 2
+      maximumFileSizeToCacheInBytes: 5 * 1024 ** 2,
+      navigateFallbackDenylist: [/^\/GDT-OpenAPI-Spec\.yaml$/]
     },
     devOptions: {
       enabled: false

--- a/packages/frontend/staticwebapp.config.json
+++ b/packages/frontend/staticwebapp.config.json
@@ -9,7 +9,11 @@
     }
   ],
   "navigationFallback": {
-    "rewrite": "/index.html"
+    "rewrite": "/index.html",
+    "exclude": ["/GDT-OpenAPI-Spec.yaml"]
+  },
+  "mimeTypes": {
+    ".yaml": "text/yaml"
   },
   "platform": {
     "apiRuntime": "node:20"


### PR DESCRIPTION
The PWA was:
* A: Not caching the spec file, and
* B: Intercepting the request

We could add the yaml to the pwa's cache, however, when the spec is updated, the user would need to empty cache and hard reload to see the new version. 

The SwaggerUI element bypasses the PWA, so it was able to see updates regardless. 