### PR TITLE
Created Spec for upgradeProvenance

### DIFF
--- a/packages/frontend/public/GDT-OpenAPI-Spec.yaml
+++ b/packages/frontend/public/GDT-OpenAPI-Spec.yaml
@@ -195,3 +195,49 @@ paths:
                   error:
                     type: string
                     example: "Invalid input parameters"
+  
+  /upgrade/{deviceKey}:
+    get:
+      tags:
+        - GDT API
+      summary: Upgrade a legacy record
+      description: This endpoint takes a legacy record and converts it to a provenance record.
+      operationId: upgradeProvenance
+      parameters:
+        - name: deviceKey
+          in: path
+          required: true
+          description: The device key of a legacy record to upgrade.
+          schema:
+            type: string
+            example: "VvaaGvt5UoyMT9iCQuncre"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+              examples:
+                SuccessfullyUpgraded:
+                  summary: Key Successfully Upgraded
+                  description: Returned when the legacy record is found and successfully recreated as a provenance record.
+                  value:
+                    recordID: "6494deafa4390304169fffbd1ad737de0c8eff1634be0550c0baa9d505e4c0a6"
+                    attachments: []
+                    oversizedAttachments: undefined
+                KeyAlreadyUpgraded:
+                  summary: Key Already Upgraded
+                  description: Returned when the key is already a provenance record.
+                  value:
+                    already-converted: true
+                KeyDoesntExist:
+                  summary: Key Doesn't Exist
+                  description: Returned when the key has valid format but does not exist in our storage.
+                  value: []
+                InvalidLegacyJSON:
+                  summary: Invalid Legacy JSON
+                  description: Returned when the legacy record exists but is not valid JSON.
+                  value:
+                    status: 404
+        '500':
+          description: Internal Server Error


### PR DESCRIPTION
Created spec for the upgradeProvenance endpoint. This endpoint takes a legacy record and converts it to a provenance record. There are multiple possible responses with status 200 so I listed all of them as examples, see the different cases below:
- Key Successfully Upgraded: Legacy record exists and was converted to a provenance record
- Key Already Upgraded: Provided key is already a provenance record
- Key Doesn't Exist: Key does not exist as a legacy or provenance record
- Invalid Legacy JSON: Legacy key exists but the record format is invalid (returns status 404 but doesn't throw it so actual status code is still 200)

Then if the key format is invalid or the backend cannot be reached we get error code 500.