### PR TITLE
Incorporated custom record titles into Group Creation Spec

### DIFF
--- a/packages/frontend/public/GDT-OpenAPI-Spec.yaml
+++ b/packages/frontend/public/GDT-OpenAPI-Spec.yaml
@@ -108,7 +108,7 @@ paths:
                       type: integer
                       example: 5
                     children_name: 
-                      type: string
+                      type: string array
                       example: ["Child1", "Child2", "Child3", "Child4", "Child5"]
                     tags:
                       type: string array

--- a/packages/frontend/public/GDT-OpenAPI-Spec.yaml
+++ b/packages/frontend/public/GDT-OpenAPI-Spec.yaml
@@ -60,6 +60,9 @@ paths:
                     number_of_children:
                       type: integer
                       example: 5
+                    children_name: 
+                      type: string
+                      example: ["Child1", "Child2", "Child3", "Child4", "Child5"]
                 attachments:
                   type: array
                   description: Optional binary files attached to the form data.


### PR DESCRIPTION
Group Creation Spec now has custom record titles for children keys.

<img width="1615" height="1464" alt="spec1" src="https://github.com/user-attachments/assets/57c9c314-9f88-443f-a714-92f9805db711" />
<img width="1200" height="1683" alt="spec2" src="https://github.com/user-attachments/assets/e274470b-f57e-45ea-9f8a-525d55bfae1e" />
<img width="1394" height="1473" alt="spec3" src="https://github.com/user-attachments/assets/5c680689-9b99-442e-a78a-78aaf7f0cbb7" />


