### PR TITLE
Drop group creation attribute auto-inheritance

### DIFF
--- a/packages/frontend/components/Forms/CreateContainer.vue
+++ b/packages/frontend/components/Forms/CreateContainer.vue
@@ -303,12 +303,12 @@ export default {
                         await postProvenance(childKey, {
                             blobType: 'deviceInitializer',
                             deviceName: childName,
-                            description: this.description,  // need to see if we want a special description when making a child
-                            tags:this.tags,
+                            description: '',
+                            tags: [],
                             children_key: '',
                             hasParent: true,
                             isPublicKey: false
-                        }, this.pictures || [])
+                        }, [])
                         
                         childrenDeviceList.push(childKey);
                         childrenDeviceName.push(childName);
@@ -329,19 +329,18 @@ export default {
             if (this.createPublicKey) {
                 // Should be higher up?
                 publicKey =  await makeEncodedDeviceKey(); //public key = public key
-                let tag_set = (this.tags).concat(['publickey']);
+                let tag_set = ['publickey'];
 
                 try {
                     await postProvenance(publicKey, {
                         blobType: 'deviceInitializer',
                         deviceName: this.name,
-                        // Is this a proper description? Should it say "public key" or something?
-                        description: this.description,
+                        description: '',
                         tags: tag_set,
                         children_key: '',
                         hasParent: true,
                         isPublicKey: true,
-                    }, this.pictures || [])
+                    }, [])
                     
                     this.$snackbar.add({
                         type: 'success',


### PR DESCRIPTION
### Summary
Group creation was copying the group's description, tags, and attachment onto every child and the public key record. 

This PR removes that copying in` CreateContainer.vue`. Since the public key also gets pushed into `childrenDeviceList`, I dropped the auto-inheritance for it too for consistency. Let me know if we'd rather keep it for the public key.
<img width="787" height="618" alt="Screenshot 2026-07-13 at 4 20 39 PM" src="https://github.com/user-attachments/assets/e799fee0-6276-42e4-9bd1-38344e940746" />


### Changes
Now children and the public key get a blank description, no tags, and no attachment. The group's own record is untouched. 
The public key keeps its `publickey` tag, since that's its own type marker, not inherited group metadata.

Out of scope: the backend's v2 createGroup endpoint — the live UI doesn't call it, so it wasn't touched.

### Tests

**1. Create a group with a description, tags, and an attached image, plus 2 children. Confirm the group record shows all three, and each child record shows none of them.**
<img width="1044" height="743" alt="Screenshot 2026-07-13 at 3 06 05 PM" src="https://github.com/user-attachments/assets/9ccdba34-aa90-4787-b24a-ad0021f9b73c" />
<img width="1041" height="753" alt="Screenshot 2026-07-13 at 3 06 26 PM" src="https://github.com/user-attachments/assets/71b8097e-264f-4200-b857-2bf2fb8534bb" />

-----
**2. Repeat Test 1 with `"Create Public Key"` checked. Confirm the public key record has no inherited description/tags/attachment, but still carries the `publickey` tag and renders correctly as "Public Key: ..." on its record page.**
<img width="575" height="685" alt="Screenshot 2026-07-13 at 4 41 21 PM" src="https://github.com/user-attachments/assets/92d4de41-69c0-4add-b435-028fc0247b19" />

<img width="969" height="752" alt="publickey" src="https://github.com/user-attachments/assets/8e8170b0-1319-4ea2-a1bb-c6dd61c0899c" />

-----
**3. Create a group with _custom child titles_. Confirm titles are still applied correctly and children still have no inherited tags, attachments, description.**
<img width="580" height="672" alt="Screenshot 2026-07-13 at 4 43 49 PM" src="https://github.com/user-attachments/assets/0c92aa5a-996d-4640-9372-7ca34ea88170" />
<img width="1123" height="756" alt="Screenshot 2026-07-13 at 4 44 20 PM" src="https://github.com/user-attachments/assets/50ece580-9b87-4a9e-be58-e062bfe6ead3" />
<img width="1129" height="757" alt="Screenshot 2026-07-13 at 4 44 37 PM" src="https://github.com/user-attachments/assets/271096b4-7833-42ad-b8f5-29e04bd29e52" />