### PR TITLE
1121 bug repeated email verified dialog pop up

### DIFF
--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -953,7 +953,7 @@ export async function postNotificationEmail(request: HttpRequest, context: Invoc
                 "DoNotReply@8577d69b-9011-4385-abec-cfe9325dbfe6.azurecomm.net",
                 email,
                 "GOSQAS Verification Code",
-                `Your verification code is: ${code} \n\nExpires in 10 minutes. \nIf you didn't request this, ignore this email.`,
+                `Your verification code is: ${code} \n\nOr click this link to verify automatically:${verifyLink} \nExpires in 10 minutes.\nIf you didn't request this, ignore this email.`,
                 "GOSQAS Notification",
                 context
             )

--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -1199,7 +1199,7 @@ export async function postResendCode(request: HttpRequest, context: InvocationCo
                 "DoNotReply@8577d69b-9011-4385-abec-cfe9325dbfe6.azurecomm.net",
                 entity.email as string,
                 "GOSQAS Verification Code",
-                `Your verification code is: ${code} \n\nExpires in 10 minutes.\nIf you didn't request this, ignore this email.`,
+                `Your verification code is: ${code} \n\nOr click this link to verify automatically:${verifyLink} \n\nExpires in 10 minutes.\nIf you didn't request this, ignore this email.`,
                 "GOSQAS Notification",
                 context
             ) 

--- a/packages/frontend/components/Modals/EmailNotification.vue
+++ b/packages/frontend/components/Modals/EmailNotification.vue
@@ -145,6 +145,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             autoCode:  { type: String, default: '' },
         },
 
+        emits: ['verification-completed'],  // to clear the props data being sent after this modal closes
+
         computed: {
             resendDisabled(): boolean {
                 return this.isResending || this.resendCooldownRemaining > 0;
@@ -322,6 +324,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                 if (notifModal) {                    
                     new Modal(notifModal).show();
                 }
+
+                this.$emit('verification-completed'); // clearing data after verification
             }
         }
     }

--- a/packages/frontend/pages/history/[deviceKey].vue
+++ b/packages/frontend/pages/history/[deviceKey].vue
@@ -159,7 +159,7 @@ const recordHasParent = hasParent(provenance);
             </div>
 
             <!-- Email notifications modal -->
-            <ModalsEmailNotification ref="emailModal" :auto-token="autoToken" :auto-code="autoCode"/>
+            <ModalsEmailNotification ref="emailModal" :auto-token="autoToken" :auto-code="autoCode" @verification-completed="clearModalEmailNotificationValues" />
 
             <section id="recalled">
               <ProvenanceFeed border="2px solid #4e3681" :disabled="!valid" :recordKey="_recordKey" :provenance="recalledRecords"/>
@@ -431,6 +431,11 @@ methods: {
 	this.isCreating = false;
 	this.isLoading = false;
 	},
+	clearModalEmailNotificationValues() {
+      // Completely clear the values to prevent the modal from remounting
+      this.autoToken = '';
+      this.autoCode = '';
+    }
 }
 };
 </script>


### PR DESCRIPTION
Issue: `autoVerify` in `EmailNotification` modal never clears the token + code after email is verified and always re-mounted on history record page.

Solution: This uses `emit` to tell the `history/[deviceKey]` page to clear the `token` and `code` after it auto verifies the email. 

Now when you create a record and verify via email, the email verification modal appears only once after clicking the email verification link.