### PR TITLE
Fixed 500 Error on Invalid API Request

### DIFF
--- a/packages/backend/src/functions/httpTrigger.ts
+++ b/packages/backend/src/functions/httpTrigger.ts
@@ -268,6 +268,7 @@ async function pathExists(containerClient: ContainerClient, path: string) {
     }
 }
 
+// Check if can place status check in here
 async function convertLegacyProvenance(containerClient: ContainerClient, key: string | Uint8Array) {
     key = typeof key === 'string' ? decodeKey(key) : key;
     const deviceID = await calculateDeviceID(key);
@@ -351,6 +352,7 @@ async function countExistingAttachments(containerClient: ContainerClient, device
 
 /* ----- API Endpoints Section 1/2: Functions ----- */
 
+// Try...catch whole fxn?
 export async function getProvenance(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
     const deviceKey = decodeKey(request.params.deviceKey);
     const deviceID = await calculateDeviceID(deviceKey);
@@ -362,7 +364,7 @@ export async function getProvenance(request: HttpRequest, context: InvocationCon
     const provExists = await pathExists(containerClient, `prov/${deviceID}`);
     if (!provExists) {
         await convertLegacyProvenance(containerClient, deviceKey);
-    }
+    } // else statement here if prov doesn't exist and return 404
 
     const records = new Array<ProvenanceRecord & { deviceID: string, timestamp: number }>();
     for await (const blob of containerClient.listBlobsFlat({ prefix: `prov/${deviceID}` })) {

--- a/packages/backend/test/IntegrationTests/Live/v1/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v1/create.test.ts
@@ -1069,6 +1069,8 @@ describe("Group Creation Tests", () => {
 
 	}, 60000);
 
+	
+
 });
 
 describe("Record Creation Tests", () => {
@@ -1193,4 +1195,15 @@ describe("Record Creation Tests", () => {
 			throw error;
 		}
 	}, 600000);
+
+	it("should return a 404 error when attempting to reach an API endpoint that doesn't exist", async () => {
+		const localUrl = "http://localhost:7071/api";
+
+		const failedProv = await fetch(`${localUrl}/provenance/garbageProv`);
+		console.log("Prov: ", failedProv)
+
+		const failedEndpoint = await fetch(`${localUrl}/garbageEndpoint`);
+		console.log("Endpoint: ", failedEndpoint)
+		
+	}, 60000);
 });

--- a/packages/backend/test/IntegrationTests/Live/v1/create.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v1/create.test.ts
@@ -1069,8 +1069,6 @@ describe("Group Creation Tests", () => {
 
 	}, 60000);
 
-	
-
 });
 
 describe("Record Creation Tests", () => {

--- a/packages/backend/test/IntegrationTests/Live/v2/read.test.ts
+++ b/packages/backend/test/IntegrationTests/Live/v2/read.test.ts
@@ -1,0 +1,1 @@
+import { describe, it, expect } from "vitest";

--- a/packages/backend/test/IntegrationTests/Live/v2/temp.txt
+++ b/packages/backend/test/IntegrationTests/Live/v2/temp.txt
@@ -1,1 +1,0 @@
-Needed to create empty folder; deleteme


### PR DESCRIPTION
We were getting status code 500 when fetching the url "https://gosqasbe.azurewebsites.net/api/provenance/totallygarbage". This is because the path is technically correct (since in provenance/{deviceKey} to reach the endpoint deviceKey just needs to have a value) and when decodeKey threw a custom error without a status code it defaulted to 500.

I've updated the code to throw status 400 (bad request, since the endpoint is correct it's just the key that's invalid) when decodeKey gets an invalid key. I've done the same for postProvenance as well (since it has the same {deviceKey} issue). **Note**: If we do decide we want this to throw 404 instead of 400 just message me either here or on Discord and I can update it.

**Note: Leaving this in draft until #1135 is merged (since the getProvenance and postProvenance specs from that PR will have to be updated to match the new 400 error code).**

Below is what the page now looks like when the key is invalid.
<img width="968" height="606" alt="Screenshot 2026-07-13 at 8 24 57 PM" src="https://github.com/user-attachments/assets/790d9a5f-60eb-47bc-8fda-4086a4c19b46" />