### PR TITLE
Fixed Heatmap Data/UI Issues

### DIFF
--- a/packages/frontend/data_viz/files/requests-by-country@5.json
+++ b/packages/frontend/data_viz/files/requests-by-country@5.json
@@ -1,26 +1,56 @@
 [
   {
     "country": "USA",
-    "requests": 4654
+    "one_year": 18661,
+    "six_months": 18661,
+    "three_months": 18661,
+    "one_month": 4789,
+    "one_week": 1718,
+    "one_day": 0
   },
   {
     "country": "CAN",
-    "requests": 1430
+    "one_year": 770,
+    "six_months": 770,
+    "three_months": 770,
+    "one_month": 90,
+    "one_week": 0,
+    "one_day": 0
   },
   {
     "country": "FRA",
-    "requests": 179
+    "one_year": 91,
+    "six_months": 91,
+    "three_months": 91,
+    "one_month": 8,
+    "one_week": 0,
+    "one_day": 0
   },
   {
     "country": "PSX",
-    "requests": 186
+    "one_year": 1342,
+    "six_months": 1342,
+    "three_months": 1342,
+    "one_month": 122,
+    "one_week": 12,
+    "one_day": 0
   },
   {
     "country": "SGP",
-    "requests": 28
+    "one_year": 1,
+    "six_months": 1,
+    "three_months": 1,
+    "one_month": 0,
+    "one_week": 0,
+    "one_day": 0
   },
   {
-    "country": "DEU",
-    "requests": 2
+    "country": "ZAF",
+    "one_year": 219,
+    "six_months": 219,
+    "three_months": 219,
+    "one_month": 172,
+    "one_week": 57,
+    "one_day": 1
   }
 ]

--- a/packages/frontend/data_viz/notebook-main.js
+++ b/packages/frontend/data_viz/notebook-main.js
@@ -561,37 +561,12 @@ function _countryNameToAlpha3(world)
 function _filteredCountryData(selectedWindow,data)
 {
   // Filter the data based on the selected timewindow
-  if (selectedWindow === "6m") {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.six_months
-    }));
-  } else if (selectedWindow === "3m") {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.three_months
-    }));
-  } else if (selectedWindow === "1m") {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.one_month
-    }));
-  } else if (selectedWindow === "1w") {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.one_week
-    }));
-  } else if (selectedWindow === "1d") {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.one_day
-    }));
-  } else {
-    return data.map(d => ({
-      country: d.country,
-      requests: d.one_year
-    }));
-  }
+  if (selectedWindow === "1d") return data.map(d => ({ country: d.country, requests: d.one_day }));
+  if (selectedWindow === "1w") return data.map(d => ({ country: d.country, requests: d.one_week }));
+  if (selectedWindow === "1m") return data.map(d => ({ country: d.country, requests: d.one_month }));
+  if (selectedWindow === "3m") return data.map(d => ({ country: d.country, requests: d.three_months }));
+  if (selectedWindow === "6m") return data.map(d => ({ country: d.country, requests: d.six_months }));
+  return data.map(d => ({ country: d.country, requests: d.one_year }));
 }
 
 

--- a/packages/frontend/data_viz/notebook-main.js
+++ b/packages/frontend/data_viz/notebook-main.js
@@ -106,7 +106,7 @@ function _chart(d3,filteredCountryData,countries,filteredRegionData,filteredCity
       .attr("d", path)
       .on("click", clicked)
     .append("title")
-      .text(d => `${d.properties.ADM0_A3}\n${valuemap.get(d.properties.ADM0_A3)}`);
+      .text(d => `${d.properties.ADM0_A3}\n${valuemap.get(d.properties.ADM0_A3) ?? "No data"} requests`);
 
   // 3. Mesh
   g.append("path")
@@ -180,7 +180,7 @@ function _chart(d3,filteredCountryData,countries,filteredRegionData,filteredCity
     .append("title")
       .text(d => {
         const key = `${d.properties.adm0_a3}|${d.properties.name}`;
-        return `${d.properties.name}\n${regionValuemap.get(key) ?? "No data"} requests`;
+        return `${d.properties.name}\n${filteredRegionValuemap.get(key) ?? "No data"} requests`;
       });
 
 
@@ -314,7 +314,7 @@ function _chart(d3,filteredCountryData,countries,filteredRegionData,filteredCity
 
 async function _data(FileAttachment){return(
 (await FileAttachment("requests-by-country@5.json").json())
-  .map(d => ({country: d.country, requests: +d.requests}))
+  .map(d => ({country: d.country, one_year: +d.one_year, six_months: +d.six_months, three_months: +d.three_months, one_month: +d.one_month, one_week: +d.one_week, one_day: +d.one_day}))
 )}
 
 function _6(md){return(
@@ -558,46 +558,40 @@ function _countryNameToAlpha3(world)
 }
 
 
-function _filteredCountryData(selectedWindow,d3,recentRequests,data,countryNameToAlpha3)
+function _filteredCountryData(selectedWindow,data)
 {
-  const now = new Date();
-  const cutoff = new Date(now);
-  if (selectedWindow === "1d") cutoff.setDate(now.getDate() - 1);
-  if (selectedWindow === "1w") cutoff.setDate(now.getDate() - 7);
-  if (selectedWindow === "1m") cutoff.setMonth(now.getMonth() - 1);
-  if (selectedWindow === "3m") cutoff.setMonth(now.getMonth() - 3);
-  if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
-  if (selectedWindow === "1y") cutoff.setFullYear(now.getFullYear() - 1);
-
-  // Temporarily just returning static data everytime (since recent-requests isn't finalized and currently only contains 20 requests)
-  return data.map(d => ({
-    country: d.country,
-    requests: d.requests
-  }));
-
-  // Note: Leaving the below code as reference, as it could potentially be helpful once we're looking at live data
-  // Make sure recentRequests are within the timeframe (look at the newest request and make sure it happened after the cutoff date)
-  // const newest = d3.max(recentRequests, d => new Date(d.time));
-  // const windowCovered = newest >= cutoff;
-
-  // if (!windowCovered) {
-  //   // If the newest request is not in our timeframe fall back to static all-time data
-  //   return data.map(d => ({
-  //     country: d.country,
-  //     requests: d.requests
-  //   }));
-  // }
-
-  // // If the newest request is within our timeframe show all requests in the timeframe
-  // const counts = d3.rollup(
-  //   recentRequests.filter(d => new Date(d.time) >= cutoff),
-  //   v => v.length,
-  //   d => d.country
-  // );
-  // return [...counts.entries()].map(([country, requests]) => ({
-  //   country: countryNameToAlpha3.get(country) || country,
-  //   requests
-  // }));
+  // Filter the data based on the selected timewindow
+  if (selectedWindow === "6m") {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.six_months
+    }));
+  } else if (selectedWindow === "3m") {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.three_months
+    }));
+  } else if (selectedWindow === "1m") {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.one_month
+    }));
+  } else if (selectedWindow === "1w") {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.one_week
+    }));
+  } else if (selectedWindow === "1d") {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.one_day
+    }));
+  } else {
+    return data.map(d => ({
+      country: d.country,
+      requests: d.one_year
+    }));
+  }
 }
 
 
@@ -726,7 +720,7 @@ export default function define(runtime, observer) {
   main.variable(null).define("selectedWindow", ["Generators", "viewof selectedWindow"], (G, _) => G.input(_));
   main.variable(null).define("detailPanel", ["selectedCity","selectedRegion","selectedCountry","html","selectedWindow","recentRequests"], _detailPanel);
   main.variable(null).define("countryNameToAlpha3", ["world"], _countryNameToAlpha3);
-  main.variable(null).define("filteredCountryData", ["selectedWindow","d3","recentRequests","data","countryNameToAlpha3"], _filteredCountryData);
+  main.variable(null).define("filteredCountryData", ["selectedWindow","data"], _filteredCountryData);
   main.variable(null).define("filteredRegionData", ["selectedWindow","d3","recentRequests"], _filteredRegionData);
   main.variable(null).define("filteredCityData", ["selectedWindow","d3","recentRequests","geocodedCities"], _filteredCityData);
   main.variable(null).define("filteredRegionValuemap", ["filteredRegionData","regionCountryLookup"], _filteredRegionValuemap);

--- a/packages/frontend/data_viz/notebook-main.js
+++ b/packages/frontend/data_viz/notebook-main.js
@@ -569,35 +569,35 @@ function _filteredCountryData(selectedWindow,d3,recentRequests,data,countryNameT
   if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
   if (selectedWindow === "1y") cutoff.setFullYear(now.getFullYear() - 1);
 
-  // Temporarily just returning static data everytime (since recent-requests isn't finalized and only contains 20 requests)
-  // Return static all-time data (since we don't currently have stored data for the different time periods)
+  // Temporarily just returning static data everytime (since recent-requests isn't finalized and currently only contains 20 requests)
   return data.map(d => ({
     country: d.country,
     requests: d.requests
   }));
 
-  // Check if recentRequests covers this window
-  const earliest = d3.min(recentRequests, d => new Date(d.time));
-  const windowCovered = earliest <= cutoff;
+  // Note: Leaving the below code as reference, as it could potentially be helpful once we're looking at live data
+  // Make sure recentRequests are within the timeframe (look at the newest request and make sure it happened after the cutoff date)
+  // const newest = d3.max(recentRequests, d => new Date(d.time));
+  // const windowCovered = newest >= cutoff;
 
-  if (!windowCovered) {
-    // Fall back to static all-time data
-    return data.map(d => ({
-      country: d.country,
-      requests: d.requests
-    }));
-  }
+  // if (!windowCovered) {
+  //   // If the newest request is not in our timeframe fall back to static all-time data
+  //   return data.map(d => ({
+  //     country: d.country,
+  //     requests: d.requests
+  //   }));
+  // }
 
-  // Use recentRequests for covered windows
-  const counts = d3.rollup(
-    recentRequests.filter(d => new Date(d.time) <= cutoff),
-    v => v.length,
-    d => d.country
-  );
-  return [...counts.entries()].map(([country, requests]) => ({
-    country: countryNameToAlpha3.get(country) || country,
-    requests
-  }));
+  // // If the newest request is within our timeframe show all requests in the timeframe
+  // const counts = d3.rollup(
+  //   recentRequests.filter(d => new Date(d.time) >= cutoff),
+  //   v => v.length,
+  //   d => d.country
+  // );
+  // return [...counts.entries()].map(([country, requests]) => ({
+  //   country: countryNameToAlpha3.get(country) || country,
+  //   requests
+  // }));
 }
 
 

--- a/packages/frontend/data_viz/notebook-main.js
+++ b/packages/frontend/data_viz/notebook-main.js
@@ -444,14 +444,15 @@ function _detailPanel(selectedCity,selectedRegion,selectedCountry,html,selectedW
   if (selectedWindow === "1m") cutoff.setMonth(now.getMonth() - 1);
   if (selectedWindow === "3m") cutoff.setMonth(now.getMonth() - 3);
   if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
-  if (selectedWindow === "1y") cutoff.setMonth(now.getFullYear() - 1);
+  if (selectedWindow === "1y") cutoff.setFullYear(now.getFullYear() - 1);
 
   // Filter based on level
   const filtered = recentRequests.filter(d => {
     const inTime = new Date(d.time) >= cutoff;
-    if (level === "city") return d.city === selectedCity.city && inTime;
-    if (level === "region") return d.region === selectedRegion && inTime;
-    if (level === "country") return d.country === selectedCountry && inTime;
+    // Using includes rather than == to catch cases like "United States" vs. "United States of America"
+    if (level === "city") return selectedCity.city.includes(d.city) && inTime;
+    if (level === "region") return selectedRegion.includes(d.region) && inTime;
+    if (level === "country") return selectedCountry.includes(d.country) && inTime;
     return false;
   });
 
@@ -562,10 +563,18 @@ function _filteredCountryData(selectedWindow,d3,recentRequests,data,countryNameT
   const now = new Date();
   const cutoff = new Date(now);
   if (selectedWindow === "1d") cutoff.setDate(now.getDate() - 1);
+  if (selectedWindow === "1w") cutoff.setDate(now.getDate() - 7);
   if (selectedWindow === "1m") cutoff.setMonth(now.getMonth() - 1);
   if (selectedWindow === "3m") cutoff.setMonth(now.getMonth() - 3);
   if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
   if (selectedWindow === "1y") cutoff.setFullYear(now.getFullYear() - 1);
+
+  // Temporarily just returning static data everytime (since recent-requests isn't finalized and only contains 20 requests)
+  // Return static all-time data (since we don't currently have stored data for the different time periods)
+  return data.map(d => ({
+    country: d.country,
+    requests: d.requests
+  }));
 
   // Check if recentRequests covers this window
   const earliest = d3.min(recentRequests, d => new Date(d.time));
@@ -581,7 +590,7 @@ function _filteredCountryData(selectedWindow,d3,recentRequests,data,countryNameT
 
   // Use recentRequests for covered windows
   const counts = d3.rollup(
-    recentRequests.filter(d => new Date(d.time) >= cutoff),
+    recentRequests.filter(d => new Date(d.time) <= cutoff),
     v => v.length,
     d => d.country
   );
@@ -597,6 +606,7 @@ function _filteredRegionData(selectedWindow,d3,recentRequests)
   const now = new Date();
   const cutoff = new Date(now);
   if (selectedWindow === "1d") cutoff.setDate(now.getDate() - 1);
+  if (selectedWindow === "1w") cutoff.setDate(now.getDate() - 7);
   if (selectedWindow === "1m") cutoff.setMonth(now.getMonth() - 1);
   if (selectedWindow === "3m") cutoff.setMonth(now.getMonth() - 3);
   if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
@@ -628,6 +638,7 @@ function _filteredCityData(selectedWindow,d3,recentRequests,geocodedCities)
   const now = new Date();
   const cutoff = new Date(now);
   if (selectedWindow === "1d") cutoff.setDate(now.getDate() - 1);
+  if (selectedWindow === "1w") cutoff.setDate(now.getDate() - 7);
   if (selectedWindow === "1m") cutoff.setMonth(now.getMonth() - 1);
   if (selectedWindow === "3m") cutoff.setMonth(now.getMonth() - 3);
   if (selectedWindow === "6m") cutoff.setMonth(now.getMonth() - 6);
@@ -661,11 +672,10 @@ function _dashboard(chart,html,detailPanel,viewofSelectedWindow)
   
   const container = html`
     <div>
-<!--  Commented out in prep for Fab26  
-<!--      <div style="margin-bottom:12px">${viewofSelectedWindow}</div> 
+      <div style="margin-bottom:12px">${viewofSelectedWindow}</div> 
 
       ${mapNode}
-<!--      ${detailPanel}
+          ${detailPanel}
     </div>
   `;
   return container;
@@ -713,9 +723,7 @@ export default function define(runtime, observer) {
   main.variable(null).define("regionValuemap", ["regionData","regionCountryLookup"], _regionValuemap);
   main.variable(null).define("recentRequests", ["FileAttachment"], _recentRequests);
   main.variable(null).define("viewof selectedWindow", ["Inputs"], _selectedWindow);
-  // Commented out for Fab26
-  //main.variable(null).define("selectedWindow", ["Generators", "viewof selectedWindow"], (G, _) => G.input(_));
-  main.variable(null).define("selectedWindow", "1y"); // Edited from the above for Fab26
+  main.variable(null).define("selectedWindow", ["Generators", "viewof selectedWindow"], (G, _) => G.input(_));
   main.variable(null).define("detailPanel", ["selectedCity","selectedRegion","selectedCountry","html","selectedWindow","recentRequests"], _detailPanel);
   main.variable(null).define("countryNameToAlpha3", ["world"], _countryNameToAlpha3);
   main.variable(null).define("filteredCountryData", ["selectedWindow","d3","recentRequests","data","countryNameToAlpha3"], _filteredCountryData);


### PR DESCRIPTION
Made requested changes to the heatmap:
- Restored the radio buttons and fixed the bug where the map would be completely grey when the time was set lower than 3 months. I did this by creating static counts for each time period (instead of trying to filter recent-requests.json, which only contains 20 records)
- Got pins to show data from recent-requests.json file
- Restored the bottom-tray and got data to appear. Bottom tray gets its data from the recent-requests.json file, not live data, which is why it only displays a few requests per region (does correctly hide requests if they’re not in the selected time range).

I also updated the country counts to exist for all time periods, but instead of doing the same for region/city I modified the code to display the number of recentRequests when hovering (instead of the static counts). This way the region/city colors, hover, and bottom tray all match.
I didn’t update the requests in recent-requests.json since I didn’t want to leak actual records, and wasn’t sure exactly how we wanted to go about filtering the data.