### PR TITLE
needs to be tested but fixed QR code url on dev site

### DIFF
--- a/deploy_test_fe.sh
+++ b/deploy_test_fe.sh
@@ -18,6 +18,7 @@ export BACKEND_URL=https://gosqasbe.azurewebsites.net/api
 export FRONTEND_URL=/
 
 # Build
+./npm-install-everything.sh
 cd packages/frontend
 rm -rf .nuxt .output
 npm run build

--- a/packages/frontend/components/QRCode.vue
+++ b/packages/frontend/components/QRCode.vue
@@ -23,6 +23,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 import { useNuxtApp } from '#app';
 import type QRCodeStyling from 'qr-code-styling';
 
+// QR Code Image
+import QRCodeImage from './gosqas_main_logo_white_border_64BitEncodedPng.txt?raw' with { type: 'text' };
+
 // Styling for custom text
 const CUSTOM_TEXT_MAX_LENGTH = 100;
 const CUSTOM_TEXT_FONT = 'bold 20px Arial, sans-serif';
@@ -62,7 +65,12 @@ export default {
         width: 322,
         height: 361,
         type: 'canvas',
+        image: "data:image/png;base64," + QRCodeImage,
         data: this.url,
+        qrOptions: {
+          typeNumber: 10,
+          errorCorrectionLevel: 'H'
+        },
         imageOptions: {
           hideBackgroundDots: false,
           imageSize: 1,

--- a/packages/frontend/components/QRCode.vue
+++ b/packages/frontend/components/QRCode.vue
@@ -21,9 +21,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 import { useNuxtApp } from '#app';
 import type QRCodeStyling from 'qr-code-styling';
 
-// QR Code Image
-import QRCodeImage from './gosqas_main_logo_white_border_64BitEncodedPng.txt?raw' with { type: 'text' };
-
 // Styling for custom text
 const CUSTOM_TEXT_MAX_LENGTH = 100;
 const CUSTOM_TEXT_FONT = 'bold 20px Arial, sans-serif';
@@ -37,7 +34,14 @@ const URL_TEXT_COLOR = '#1E2019';
 const PADDING = 5; // Padding between text blocks and the QR code
 const QR_SCALE_WITH_CUSTOM_TEXT = 0.9; // Scale down QR code when custom text is shown
 
-
+function normalizeUrl(url: string): string { 
+  /* when dev is deployed the frontend url is `/` which is why there is a bug for qrCode on dev */ 
+  if(/^https?:\/\//i.test(url)){
+    return url;
+  }
+  const cleanPath = url.replace(/^\//, "");
+  return `$window.location.origin/${cleanPath}`;
+}
 
 export default {
   props: {
@@ -55,7 +59,6 @@ export default {
         width: 322,
         height: 361,
         type: 'canvas',
-        image: "data:image/png;base64," + QRCodeImage,
         data: this.url,
         imageOptions: {
           hideBackgroundDots: false,
@@ -92,7 +95,7 @@ export default {
   watch: {
     url(newValue: string | undefined) {
       if (newValue) {
-        this.options.data = newValue;
+        this.options.data = normalizeUrl(newValue);
         this.qrCodeStyling?.update(this.options);
       }
     }

--- a/packages/frontend/components/QRCode.vue
+++ b/packages/frontend/components/QRCode.vue
@@ -13,6 +13,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
+
+
 <template>
   <div ref="qrCode", class="qr"></div>
 </template>
@@ -42,6 +44,7 @@ function normalizeUrl(url: string): string {
   const cleanPath = url.replace(/^\//, "");
   return `$window.location.origin/${cleanPath}`;
 }
+
 
 export default {
   props: {
@@ -169,7 +172,7 @@ export default {
         customLines = this.wrapText(limitedText, CUSTOM_TEXT_FONT, qrCanvas.width - 20);
         customTextHeight = customLines.length * CUSTOM_TEXT_LINE_HEIGHT + 10;
 
-        urlLines = this.wrapText(this.url, URL_FONT, qrCanvas.width - 20);
+        urlLines = this.wrapText(window.location.href, URL_FONT, qrCanvas.width - 20);
         urlHeight = urlLines.length * URL_LINE_HEIGHT + PADDING;
       }
 


### PR DESCRIPTION
This bug seems to be related to dev site exclusively. When the frontend dev is deployed, `FRONTEND_URL=/` . Hence, why `/` is seen as the url of origin for the frontend. 

Still need to test on dev to confirm that this fix works.