### PR TITLE
[Bug Fix] CSV Erroneously Treats First Child Key as Public Key 

### DIFF
--- a/packages/frontend/components/csvFile.vue
+++ b/packages/frontend/components/csvFile.vue
@@ -24,7 +24,7 @@ export default {
                 const childrenKeys = await getChildrenKeys(this.recordKey);
 
                 const publicRecord = provenance?.[0]?.record;
-                const publicKey = publicRecord?.children_key?.[0] || publicRecord?.publicKey || '';
+                const publicKey = publicRecord?.publicKey || '';
 
                 const parentUrl = (window.location.origin + this.$route.fullPath).replace(/,+$/, '');
                 const parentName = publicRecord.deviceName?.replace(/"/g, '""') || '';


### PR DESCRIPTION
Modified code to have public key set to empty string instead of first child key when there is no public key requested by user.

With public key:
<img width="2376" height="231" alt="with_public_key" src="https://github.com/user-attachments/assets/5a1d9009-442b-4dab-aa12-6f446ad58464" />

Without public key:
<img width="1951" height="147" alt="no_public_key" src="https://github.com/user-attachments/assets/492e4f25-b483-42c5-bc63-301179d4f0a9" />
