### PR TITLE
Updated Offline Queue Stash

### DIFF
--- a/packages/frontend/pages/offline-edits.vue
+++ b/packages/frontend/pages/offline-edits.vue
@@ -59,7 +59,7 @@ while offline.
         </div>
     </div>
     <!----------------Queued Keys Banner-------------------->
-    <div v-for="(key, index) in offlineKeys">
+    <div v-for="(key, index) in queuedKeys">
         <div class="key-box">
             <p style="font-size: 17px;">{{ key }}</p>
             <div style="background-color: #91bdf5; border-radius: 20px; width: 105px; color: black; text-align: center; height:40px; display:flex; justify-content: center; align-items: center;">Queued</div>
@@ -99,7 +99,7 @@ data() {
         dismissAllEditsPopUp: false,
         dismissPublishedEditsPopUp: false,
         dismissSingleEditPopUp: false,
-        offlineKeys: [] as string[],
+        queuedKeys: [] as string[],
         fulfilledKeys: [] as string[],
         failedKeys: [] as string[],
 	}
@@ -108,7 +108,7 @@ data() {
 async mounted() {
     try {
         this.getFailedKeys();
-        this.getOfflineKeys();
+        this.getQueuedKeys();
         this.getFulfilledKeys();
         this.clearOneEdit();
     } catch (error) {
@@ -121,14 +121,17 @@ async mounted() {
 },
 
 methods: {
-    getOfflineKeys() {
-        // Get all keys that were successfully stashed while offline
-        let stash_counter = parseInt(localStorage.getItem('stash_counter') || "0");
-        for (stash_counter; stash_counter > 0; stash_counter--) {
-            let stashedRequest = JSON.parse(localStorage.getItem('gosqas-offline-stash-' + stash_counter) || '{}')
-            let fullUrl = stashedRequest[0][1]
-            let record = fullUrl.split("/")[fullUrl.split("/").length - 1]
-            this.offlineKeys.push(record)   
+    getQueuedKeys() {
+        let queued = localStorage.getItem("gdt-stash-failed") || '{}';
+        if (queued == '[{}]' || queued == '{}') {
+            return
+        }
+
+        for (const request of JSON.parse(queued)) {
+            if (JSON.stringify(request) !== "{}") {
+                let key = request["key"];
+                this.queuedKeys.push(key);
+            }
         }
     },
     getFulfilledKeys() {
@@ -149,23 +152,15 @@ methods: {
 
         for (const request of JSON.parse(failed)) {
             if (JSON.stringify(request) !== "{}") {
-                let fullUrl = request[0][1];
-                this.failedKeys.push(fullUrl.split("/")[fullUrl.split("/").length - 1]);
+                let key = request["key"];
+                this.failedKeys.push(key);
             }
         }
     },
     clearAllEdits() {
-        let stash_counter = parseInt(localStorage.getItem('stash_counter') || "0");
-        for (stash_counter; stash_counter > 0; stash_counter--) {
-            let request_name = 'gosqas-offline-stash-' + stash_counter;
-            let old_request_name = 'gosqas_offline_stash_' + stash_counter;
-            localStorage.removeItem(request_name);
-            localStorage.removeItem(old_request_name);
-        }
-        localStorage.setItem('stash_counter', '0');
-        localStorage.removeItem('gdt-stash-syncing');
-        localStorage.removeItem('gdt-stash-fulfilled');
+        localStorage.removeItem('gdt-stash-queued');
         localStorage.removeItem('gdt-stash-failed');
+        localStorage.removeItem('gdt-stash-fulfilled');
         window.location.reload();
     },
     clearPublishedEdits() {
@@ -188,7 +183,6 @@ methods: {
             this.dismissOneKey = '';
             this.dismissSingleEditPopUp = false;
         }
-        localStorage.setItem('gdt-stash-fulfilled', '')
         localStorage.setItem('gdt-stash-fulfilled', this.fulfilledKeys.toString())
     },
     async retrySyncing(key: string, index: number) {
@@ -207,7 +201,7 @@ methods: {
                 return;
             }
 
-            let stashedRecord = JSON.parse(stashedRequest[1][1] || '{}');
+            let stashedRecord = JSON.parse(stashedRequest["data"] || '{}');
 
             // Try to post the record/group and display an error if it fails
             await postProvenance(key, stashedRecord, []);
@@ -242,7 +236,7 @@ methods: {
                 return;
             }
 
-            let stashedRecord = JSON.parse(stashedRequest[1][1] || '{}');
+            let stashedRecord = JSON.parse(stashedRequest["data"] || '{}');
             let isGroup = false;
 
             if (stashedRecord.children_name) {

--- a/packages/frontend/services/azureFuncs.ts
+++ b/packages/frontend/services/azureFuncs.ts
@@ -225,25 +225,25 @@ async function fetchUrl(url: string, formData?: FormData) {
     }
 }
 
-export function stashOfflineRequest(currentKey: string, stashName: string, request?: string) {
-    // Function to stash an offline request (works for fulfilled and failed stashes)
+export function stashOfflineRequest(currentKey: string, stashName: string, request?: any) {
+    // Function to stash an offline request (works for queued, failed, and fulfilled stashes)
     try {
         let requests = [];
-        let stash = localStorage.getItem(stashName) || "{}";
+        let stash = localStorage.getItem(stashName) || "[]";
         let existingRequests;
 
         // Get the previous requests from the stash
-        if (stashName.includes("failed")) {
-            existingRequests = JSON.parse(stash);
-        } else {
+        if (stashName.includes("fulfilled")) {
             existingRequests = stash.split(",");
+        } else {
+            existingRequests = JSON.parse(stash);
         }
 
         // Get the existing stashed requests, skip the loop if there are none
-        if (JSON.stringify(existingRequests) !== "{}" && JSON.stringify(existingRequests) !== '["{}"]') {
+        if (JSON.stringify(existingRequests) !== "[]" && JSON.stringify(existingRequests) !== '["[]"]') {
             for (const storedRequest of existingRequests) {
                 // If new request == existing request, exit without updating the stash
-                if ((request && storedRequest[0][1] == request[0][1]) || storedRequest == currentKey) {
+                if ((request && storedRequest["data"] == request) || storedRequest == currentKey) {
                     return;
                 }
 
@@ -252,12 +252,12 @@ export function stashOfflineRequest(currentKey: string, stashName: string, reque
         }
 
         // Add the new request and set the new stash value
-        if (stashName.includes("failed")) {
-            requests.push(request);
-            localStorage.setItem(stashName, JSON.stringify(requests));
-        } else {
+        if (stashName.includes("fulfilled")) {
             requests.push(currentKey);
             localStorage.setItem(stashName, requests.toString());
+        } else {
+            requests.push({"key": currentKey, "data": request});
+            localStorage.setItem(stashName, JSON.stringify(requests));
         }
 
     } catch (error) {
@@ -267,29 +267,36 @@ export function stashOfflineRequest(currentKey: string, stashName: string, reque
 }
 
 export function removeOfflineRequest(currentKey: string, stashName: string) {
-    // Function to remove an offline request from the stash (works for fulfilled and failed stashes)
+    // Function to remove an offline request from the stash (works for queued, failed, and fulfilled stashes)
     try {
         let requests = [];
-        let stash = localStorage.getItem(stashName) || "{}";
+        let stash = localStorage.getItem(stashName) || "[]";
         let existingRequests;
 
         // Get the previous requests from the stash
-        if (stashName.includes("failed")) {
-            existingRequests = JSON.parse(stash);
-        } else {
+        if (stashName.includes("fulfilled")) {
             existingRequests = stash.split(",");
+        } else {
+            existingRequests = JSON.parse(stash);
         }
 
         // If there are no previous requests exit the function (nothing to remove)
-        if (JSON.stringify(existingRequests) == "{}" || JSON.stringify(existingRequests) == '["{}"]') {
+        if (JSON.stringify(existingRequests) == "[]" || JSON.stringify(existingRequests) == '["[]"]') {
             return;
         }
 
-        if (stashName.includes("failed")) {
-            // Remove request from failed stash
+        if (stashName.includes("fulfilled")) {
+            // Remove key from the fulfilled stash
+            const index = existingRequests.indexOf(currentKey);
+            if (index > -1) {
+                existingRequests.splice(index, 1);
+            }
+            localStorage.setItem(stashName, existingRequests.toString())
+            
+        } else {
+            // Remove request from the queue/failed stash
             for (let i = 0; i < existingRequests.length; i++) {
-                let fullUrl = existingRequests[i][0][1];
-                let requestKey = fullUrl.split("/")[fullUrl.split("/").length - 1];
+                let requestKey = existingRequests[i]["key"];
 
                 // Add back all requests except the one we're removing 
                 if (requestKey != currentKey) {
@@ -297,13 +304,6 @@ export function removeOfflineRequest(currentKey: string, stashName: string) {
                 }
             }
             localStorage.setItem(stashName, JSON.stringify(requests))
-        } else {
-            // Remove key from fulfilled stash
-            const index = existingRequests.indexOf(currentKey);
-            if (typeof existingRequests != "string" && index > -1) {
-                existingRequests.splice(index, 1);
-            }
-            localStorage.setItem(stashName, existingRequests.toString())
         }
 
     } catch (error) {

--- a/packages/frontend/test/unitTests/azureFuncs.spec.ts
+++ b/packages/frontend/test/unitTests/azureFuncs.spec.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { describe, expect, it, vi } from 'vitest';
 import { makeEncodedDeviceKey } from '../../../backend/src/utils/keyFuncs';
+import { stashOfflineRequest, removeOfflineRequest } from '~/services/azureFuncs';
 
 async function createRequest (
   name: string,
@@ -24,14 +25,120 @@ async function createRequest (
 
 function resetStashValues(): void {
   // reset the values in localStorage to avoid overlap between tests
-  localStorage.setItem('stash_counter', '0');
-  localStorage.setItem('gdt-stash-fulfilled', '');
+  localStorage.setItem('gdt-stash-queued', '');
   localStorage.setItem('gdt-stash-failed', '');
-  localStorage.setItem('gdt-awaiting-conectivity', 'false');
+  localStorage.setItem('gdt-stash-fulfilled', '');
 }
 
-describe("Placeholder tests", () => {
-    it("Future offline tests will go here", () => {
-        expect(true).toBe(true);
-    });
+describe("Stash and Remove Offline Requests", () => {
+  it("Stash and Remove from Queue Stash", async () => {
+    resetStashValues();
+    let [queuedKey, queuedData] = await createRequest(
+      'Queued Record',
+      'Test for queue stash'
+    );
+
+    // Stash the request and confirm it was successful
+    stashOfflineRequest(queuedKey, "gdt-stash-queued", queuedData.get('provenanceRecord'));
+
+    let requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-queued') || '{}');
+    let queuedRequest = requestFromStash[0];
+    expect(requestFromStash.length).toEqual(1);
+    expect(queuedRequest["key"]).toEqual(queuedKey);
+    expect(queuedRequest["data"]).toStrictEqual(queuedData.get('provenanceRecord'));
+
+    // Try to add the same record twice and confirm it wasn't added
+    stashOfflineRequest(queuedKey, "gdt-stash-queued", queuedData.get('provenanceRecord'));
+
+    requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-queued') || '{}');
+    queuedRequest = requestFromStash[0];
+    expect(requestFromStash.length).toEqual(1);
+    expect(queuedRequest["key"]).toEqual(queuedKey);
+    expect(queuedRequest["data"]).toStrictEqual(queuedData.get('provenanceRecord'));
+
+    // Remove the request and confirm it was successful
+    removeOfflineRequest(queuedKey, "gdt-stash-queued");
+
+    requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-queued') || '{}');
+    queuedRequest = requestFromStash[0];
+    expect(requestFromStash).toEqual([]);
+    expect(queuedRequest).toBeUndefined();
+  });
+
+  it("Stash and Remove 2 Requests from Failed Stash", async () => {
+    resetStashValues();
+    let [failedKey, failedData] = await createRequest(
+      'Failed Record',
+      'Test for failed stash'
+    );
+    let [failedKey2, failedData2] = await createRequest(
+      'Failed Record 2',
+      'Second test for failed stash'
+    );
+
+    // Stash 2 failed requests and confirm both were successfully stored
+    stashOfflineRequest(failedKey, "gdt-stash-failed", failedData.get('provenanceRecord'));
+    stashOfflineRequest(failedKey2, "gdt-stash-failed", failedData2.get('provenanceRecord'));
+
+    let requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-failed') || '{}');
+    let failedRequest = requestFromStash[0];
+    let failedRequest2 = requestFromStash[1];
+    expect(requestFromStash.length).toEqual(2);
+    expect(failedRequest["key"]).toEqual(failedKey);
+    expect(failedRequest2["key"]).toEqual(failedKey2);
+    expect(failedRequest["data"]).toStrictEqual(failedData.get('provenanceRecord'));
+    expect(failedRequest2["data"]).toStrictEqual(failedData2.get('provenanceRecord'));
+
+    // Remove both failed requests and confirm they were successfully removed
+    removeOfflineRequest(failedKey, "gdt-stash-failed");
+
+    requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-failed') || '{}');
+    failedRequest = requestFromStash[0];
+    // First request was removed, so the new first request should be failedKey2/failedData2
+    expect(requestFromStash.length).toEqual(1);
+    expect(failedRequest["key"]).toEqual(failedKey2);
+    expect(failedRequest["data"]).toStrictEqual(failedData2.get('provenanceRecord'));
+
+    removeOfflineRequest(failedKey2, "gdt-stash-failed");
+
+    requestFromStash = JSON.parse(localStorage.getItem('gdt-stash-failed') || '{}');
+    failedRequest = requestFromStash[0];
+    expect(requestFromStash.length).toEqual(0);
+    expect(failedRequest).toBeUndefined();
+  });
+
+  it("Stash and Remove from Fulfilled Stash", async () => {
+    resetStashValues();
+    let [fulfilledKey, fulfilledData] = await createRequest(
+      'Fulfilled Record',
+      'Test for fulfilled stash'
+    );
+
+    // Stash the request and confirm it was successful
+    stashOfflineRequest(fulfilledKey, "gdt-stash-fulfilled");
+
+    let requestFromStash = localStorage.getItem('gdt-stash-fulfilled') || '';
+    let fulfilledKeys = requestFromStash.split(",");
+    let returnedKey = fulfilledKeys[0];
+    expect(fulfilledKeys.length).toEqual(1);
+    expect(returnedKey).toEqual(fulfilledKey);
+
+    // Try to add the same record twice and confirm it wasn't added
+    stashOfflineRequest(fulfilledKey, "gdt-stash-fulfilled");
+
+    requestFromStash = localStorage.getItem('gdt-stash-fulfilled') || '';
+    fulfilledKeys = requestFromStash.split(",");
+    returnedKey = fulfilledKeys[0];
+    expect(fulfilledKeys.length).toEqual(1);
+    expect(returnedKey).toEqual(fulfilledKey);
+
+    // Remove the request and confirm it was successful
+    removeOfflineRequest(fulfilledKey, "gdt-stash-fulfilled");
+
+    requestFromStash = localStorage.getItem('gdt-stash-fulfilled') || '';
+    fulfilledKeys = requestFromStash.split(",");
+    returnedKey = fulfilledKeys[0];
+    expect(requestFromStash).toEqual('');
+    expect(returnedKey).toEqual('');
+  });
 });


### PR DESCRIPTION
Implemented the queue stash (gdt-stash-queued) and updated the failed stash layout in stashOfflineRequest and removeOfflineRequest. I updated our offline edits page to be able to display our new stash layout format, and wrote some tests to make sure the new layouts are working as intended.

The new layout is this (I used the record instead of formData since we can only store strings in localStorage:
- gdt-stash-queue = [{“key”: key, “data”: record2}, {“key”: key2, “data”: record2}, ...]
- gdt-stash-failed = [{“key”: key, “data”: record2}, {“key”: key2, “data”: record2}, ...]

Note: Since there was a lot of overlap between issues #1185 and #1191 I've gone ahead and solved both in this PR.